### PR TITLE
Update to 0.6 + creation of compressed introductory notebook

### DIFF
--- a/Chapter0_Motivation.ipynb
+++ b/Chapter0_Motivation.ipynb
@@ -82,11 +82,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "matvec (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "function matvec(A, x)\n",
     "    B = zeros(size(A,1))\n",
@@ -114,27 +123,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "6.821210263296962e-13"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "N = 1000\n",
     "A = rand(N,N)\n",
     "x = rand(N,1)\n",
     "B1 = A*x\n",
     "B2 = matvec(A, x)\n",
-    "maximum(abs(B1-B2))"
+    "maximum(abs.(B1-B2))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0.001718 seconds (85 allocations: 14.373 KiB)\n",
+      "  0.001825 seconds (5 allocations: 8.094 KiB)\n"
+     ]
+    }
+   ],
    "source": [
     "@time A*x\n",
     "@time matvec(A,x);"
@@ -153,11 +178,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "*<i>{T, S}</i>(A::<b>AbstractArray{T,2}</b>, B::<b>AbstractArray{S,2}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/matmul.jl#L145\" target=\"_blank\">linalg/matmul.jl:145</a>"
+      ],
+      "text/plain": [
+       "*(A::AbstractArray{T,2}, B::AbstractArray{S,2}) where {T, S} in Base.LinAlg at linalg/matmul.jl:145"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "@which A*x"
    ]
@@ -238,11 +275,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "my_fft (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "function my_fft(x)\n",
     "    N = length(x)\n",
@@ -271,14 +317,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.4684476073050944e-15"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "a = rand(128)\n",
-    "maximum(abs(fft(a)-my_fft(a)))"
+    "maximum(abs.(fft(a)-my_fft(a)))"
    ]
   },
   {
@@ -290,14 +345,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.4684476073050944e-15"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "F = plan_fft(a)\n",
-    "maximum(abs(F*a - my_fft(a)))"
+    "maximum(abs.(F*a - my_fft(a)))"
    ]
   },
   {
@@ -309,11 +373,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0.000116 seconds (67 allocations: 35.875 KiB)\n",
+      "  0.000016 seconds (7 allocations: 32.453 KiB)\n",
+      "  0.000588 seconds (8.19 k allocations: 721.828 KiB)\n"
+     ]
+    }
+   ],
    "source": [
     "a = rand(1024)\n",
     "@time b1 = fft(a)\n",
@@ -365,22 +437,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2.0"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "4/2"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Float64"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "typeof(4/2)"
    ]
@@ -394,11 +484,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "Int(4/2)"
    ]
@@ -412,22 +511,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "4>>1"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Int64"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "typeof(4 >> 1)"
    ]
@@ -441,11 +558,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1.5"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "3/2"
    ]
@@ -486,17 +612,17 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 0.4.0",
+   "display_name": "Julia 0.6.0",
    "language": "julia",
-   "name": "julia-0.4"
+   "name": "julia-0.6"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "0.4.0"
+   "version": "0.6.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/Chapter1_Syntax.ipynb
+++ b/Chapter1_Syntax.ipynb
@@ -33,88 +33,171 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "33"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "x = 33"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2.0"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "y = 2.0"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"Hello, I am a string.\""
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "z = \"Hello, I am a string.\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2//1"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "a = 4 // 2    # this is a Julia-style rational number"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1×4 Array{Int64,2}:\n",
+       " 1  2  3  4"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "[1 2 3 4]   # a row vector"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4-element Array{Int64,1}:\n",
+       " 1\n",
+       " 2\n",
+       " 3\n",
+       " 4"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "[1, 2, 3, 4]   # and a column vector"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2×4 Array{Int64,2}:\n",
+       " 1  2  3  4\n",
+       " 5  6  7  8"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "[1 2 3 4; 5 6 7 8]    # and a Matlab-style matrix"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4-element Array{Int64,1}:\n",
+       " 1\n",
+       " 2\n",
+       " 3\n",
+       " 4"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "[1; 2; 3; 4]"
    ]
@@ -128,33 +211,60 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "35.0"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "x+y"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "33.0"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "x*y/2"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Int64"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "typeof(x)"
    ]
@@ -172,11 +282,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4-element Array{Int64,1}:\n",
+       " 1\n",
+       " 2\n",
+       " 3\n",
+       " 4"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "a = [1, 2, 3, 4]"
    ]
@@ -190,11 +313,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4-element Array{Int64,1}:\n",
+       " 1\n",
+       " 5\n",
+       " 3\n",
+       " 4"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "b = a\n",
     "b[2] = 5\n",
@@ -203,11 +339,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4-element Array{Int64,1}:\n",
+       " 1\n",
+       " 5\n",
+       " 3\n",
+       " 4"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "a"
    ]
@@ -221,11 +370,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4-element Array{Int64,1}:\n",
+       " 1\n",
+       " 7\n",
+       " 3\n",
+       " 4"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "c = copy(b)\n",
     "c[2] = 7\n",
@@ -234,11 +396,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4-element Array{Int64,1}:\n",
+       " 1\n",
+       " 5\n",
+       " 3\n",
+       " 4"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "b"
    ]
@@ -261,11 +436,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "a = 4\n",
     "b = a\n",
@@ -274,22 +458,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "a"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "b"
    ]
@@ -328,22 +530,54 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "10-element Array{Int64,1}:\n",
+       "       1\n",
+       "       2\n",
+       "       6\n",
+       "      24\n",
+       "     120\n",
+       "     720\n",
+       "    5040\n",
+       "   40320\n",
+       "  362880\n",
+       " 3628800"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "a = [factorial(i) for i=1:10]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4×4 Array{Float64,2}:\n",
+       " 0.5       0.333333  0.25      0.2     \n",
+       " 0.333333  0.25      0.2       0.166667\n",
+       " 0.25      0.2       0.166667  0.142857\n",
+       " 0.2       0.166667  0.142857  0.125   "
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "A = [1/(i+j) for i=1:4,j=1:4]"
    ]
@@ -366,44 +600,83 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2.362055933483194e-9"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "det(A)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "([-0.734333 0.630046 -0.247002 -0.0527918; -0.489555 -0.248892 0.735949 0.395938; -0.367167 -0.487684 0.0168558 -0.791877; -0.293733 -0.550689 -0.630147 0.461928], [-0.68089 -0.489555 -0.384651 -0.317628; 0.0 -0.0415261 -0.0522176 -0.0539782; 0.0 0.0 -0.00177233 -0.00310257; 0.0 0.0 0.0 4.71355e-5])"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "qr(A)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "([-0.695242 0.662773 -0.272282 -0.0568608; -0.502448 -0.188579 0.738785 0.407652; -0.395998 -0.463099 0.0491555 -0.791397; -0.327674 -0.557413 -0.614526 0.451971], [0.977556, 0.0622678, 0.00182126, 2.13066e-5], [-0.695242 0.662773 -0.272282 -0.0568608; -0.502448 -0.188579 0.738785 0.407652; -0.395998 -0.463099 0.0491555 -0.791397; -0.327674 -0.557413 -0.614526 0.451971])"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "svd(A)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "svd(A::<b>Union{AbstractArray, Number}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/svd.jl#L106\" target=\"_blank\">linalg/svd.jl:106</a>"
+      ],
+      "text/plain": [
+       "svd(A::Union{AbstractArray, Number}) in Base.LinAlg at linalg/svd.jl:106"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "@which svd(A)"
    ]
@@ -426,33 +699,66 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2×2 Array{Int64,2}:\n",
+       " 1  2\n",
+       " 3  4"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "B = [1 2; 3 4]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2×2 Array{Int64,2}:\n",
+       " 1   4\n",
+       " 9  16"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "B.*B"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2×2 Array{Int64,2}:\n",
+       " 1   4\n",
+       " 9  16"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "B.^2"
    ]
@@ -466,22 +772,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2×2 Array{Int64,2}:\n",
+       "  7  10\n",
+       " 15  22"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "B*B"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2×2 Array{Int64,2}:\n",
+       "  7  10\n",
+       " 15  22"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "B^2"
    ]
@@ -497,11 +825,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "in (generic function with 26 methods)"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "∈"
    ]
@@ -515,22 +852,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "true"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "in(5, [3 5])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "true"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "5 ∈ [3 5]"
    ]
@@ -557,11 +912,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "fibonacci (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "function fibonacci(n)\n",
     "    if (n == 1) || (n==0)\n",
@@ -574,22 +938,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "8"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "fibonacci(5)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "11-element Array{Int64,1}:\n",
+       "  1\n",
+       "  1\n",
+       "  2\n",
+       "  3\n",
+       "  5\n",
+       "  8\n",
+       " 13\n",
+       " 21\n",
+       " 34\n",
+       " 55\n",
+       " 89"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "[fibonacci(i) for i = 0:10]"
    ]
@@ -603,33 +996,60 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "sqr (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "sqr(x) = x*x"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "25"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "sqr(5)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "25.0"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "sqr(5.0)"
    ]
@@ -643,11 +1063,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "my_maximum (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "function my_maximum(x,y)\n",
     "    if x > y\n",
@@ -660,11 +1089,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "my_maximum(2,3)"
    ]
@@ -678,11 +1116,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "my_maximum (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "my_maximum(x,y) = (x>y) ? x : y"
    ]
@@ -696,11 +1143,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(::#7) (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "x -> cos(x)"
    ]
@@ -714,22 +1170,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "composite (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "composite(f, g, x) = f(g(x))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.9803300732314021"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "composite(cos, sin, 0.2)"
    ]
@@ -743,11 +1217,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "composite(-, -, 1)"
    ]
@@ -774,22 +1257,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\t.text\n",
+      "Filename: In[37]\n",
+      "\tpushq\t%rbp\n",
+      "\tmovq\t%rsp, %rbp\n",
+      "Source line: 1\n",
+      "\timulq\t%rdi, %rdi\n",
+      "\tmovq\t%rdi, %rax\n",
+      "\tpopq\t%rbp\n",
+      "\tretq\n",
+      "\tnopl\t(%rax)\n"
+     ]
+    }
+   ],
    "source": [
     "@code_native sqr(5)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\t.text\n",
+      "Filename: In[37]\n",
+      "\tpushq\t%rbp\n",
+      "\tmovq\t%rsp, %rbp\n",
+      "Source line: 1\n",
+      "\tmulsd\t%xmm0, %xmm0\n",
+      "\tpopq\t%rbp\n",
+      "\tretq\n",
+      "\tnopw\t(%rax,%rax)\n"
+     ]
+    }
+   ],
    "source": [
     "@code_native sqr(5.0)"
    ]
@@ -820,22 +1332,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "CodeInfo(:(begin \n",
+       "        nothing\n",
+       "        return x * x\n",
+       "    end))"
+      ]
+     },
+     "execution_count": 49,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "@code_lowered sqr(5)   # show the lowered AST tree"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "CodeInfo(:(begin \n",
+       "        return (Base.mul_int)(x, x)::Int64\n",
+       "    end))=>Int64"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "@code_typed sqr(5)     # the AST tree, optimized and augmented with type information\n",
     "# note the return type on the last line, following end"
@@ -843,22 +1378,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 51,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "define i64 @julia_sqr_61382(i64) #0 !dbg !5 {\n",
+      "top:\n",
+      "  %1 = mul i64 %0, %0\n",
+      "  ret i64 %1\n",
+      "}\n"
+     ]
+    }
+   ],
    "source": [
     "@code_llvm sqr(5)      # LLVM instructions"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\t.text\n",
+      "Filename: In[37]\n",
+      "\tpushq\t%rbp\n",
+      "\tmovq\t%rsp, %rbp\n",
+      "Source line: 1\n",
+      "\timulq\t%rdi, %rdi\n",
+      "\tmovq\t%rdi, %rax\n",
+      "\tpopq\t%rbp\n",
+      "\tretq\n",
+      "\tnopl\t(%rax)\n"
+     ]
+    }
+   ],
    "source": [
     "@code_native sqr(5)     # native assembler code"
    ]
@@ -874,11 +1435,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1\n",
+      "2\n",
+      "3\n",
+      "4\n",
+      "5\n",
+      "6\n",
+      "7\n",
+      "8\n",
+      "9\n",
+      "10\n"
+     ]
+    }
+   ],
    "source": [
     "for i = 1:10\n",
     "    println(i)\n",
@@ -887,11 +1463,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 54,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1\n",
+      "2\n",
+      "3\n",
+      "4\n",
+      "5\n",
+      "6\n",
+      "7\n",
+      "8\n",
+      "9\n",
+      "10\n"
+     ]
+    }
+   ],
    "source": [
     "i = 0\n",
     "while (i < 10)\n",
@@ -909,33 +1500,66 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1:10"
+      ]
+     },
+     "execution_count": 55,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "1:10"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 56,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "UnitRange{Int64}"
+      ]
+     },
+     "execution_count": 56,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "typeof(1:10)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 57,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1\n",
+      "2\n",
+      "3\n",
+      "4\n",
+      "5\n",
+      "6\n",
+      "7\n",
+      "8\n",
+      "9\n",
+      "10\n"
+     ]
+    }
+   ],
    "source": [
     "for i in 1:10\n",
     "    println(i)\n",
@@ -944,11 +1568,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 58,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1\n",
+      "4\n",
+      "0\n"
+     ]
+    }
+   ],
    "source": [
     "for i in [1,4,0]\n",
     "    println(i)\n",
@@ -957,11 +1589,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 59,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hey, I was expecting that.\n"
+     ]
+    }
+   ],
    "source": [
     "if 2 < 3\n",
     "    println(\"Hey, I was expecting that.\")\n",
@@ -990,11 +1628,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 60,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "twosum (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 60,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "function twosum(x)\n",
     "    # code goes here\n",
@@ -1003,7 +1650,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 61,
    "metadata": {
     "collapsed": true
    },
@@ -1039,13 +1686,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 65,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3×3 Array{Float64,2}:\n",
+       " -0.408902  -0.518109  -0.150969\n",
+       "  0.314941   0.399053   0.116278\n",
+       "  0.749229   0.949328   0.276619"
+      ]
+     },
+     "execution_count": 65,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "A = cos([1; 2; 3]) * sin([4 5 6])"
+    "A = cos.([1; 2; 3]) * sin.([4 5 6])"
    ]
   },
   {
@@ -1057,11 +1716,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 63,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "largenumbers (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 63,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "function largenumbers(A)\n",
     "    # code goes here. Test whether elements are great than zero, and print them ('println(a)')\n",
@@ -1070,11 +1738,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 64,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "largenumbers (generic function with 2 methods)"
+      ]
+     },
+     "execution_count": 64,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "function largenumbers(A, threshold)\n",
     "    # code goes here\n",
@@ -1102,17 +1779,17 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 0.4.0",
+   "display_name": "Julia 0.6.0",
    "language": "julia",
-   "name": "julia-0.4"
+   "name": "julia-0.6"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "0.4.0"
+   "version": "0.6.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/Chapter2_Types.ipynb
+++ b/Chapter2_Types.ipynb
@@ -58,10 +58,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 1,
+   "metadata": {},
    "outputs": [],
    "source": [
     "type MyType\n",
@@ -80,99 +78,180 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MyType(5)"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "v = MyType(5)    # We instantiate an object of type MyType. There is a default constructor."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "v.a"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MyType"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "typeof(v)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Int64"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "typeof(v.a)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MyType(5.0)"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "v2 = MyType(5.0)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MyType"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "typeof(v2)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Float64"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "typeof(v2.a)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"Now I am a string\""
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "v2.a = \"Now I am a string\"      # This is allowed. The type of a is not restricted, and it can change."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MyType(\"Now I am a string\")"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "v2"
    ]
@@ -193,7 +272,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {
     "collapsed": true
    },
@@ -213,33 +292,61 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MyType2(2.0)"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "v = MyType2(2)      # Note the integer I've supplied is automatically converted to a float"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4.0"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "v.a = 4.0"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "LoadError",
+     "evalue": "\u001b[91mMethodError: Cannot `convert` an object of type String to an object of type Float64\nThis may have arisen from a call to the constructor Float64(...),\nsince type constructors fall back to convert methods.\u001b[39m",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[91mMethodError: Cannot `convert` an object of type String to an object of type Float64\nThis may have arisen from a call to the constructor Float64(...),\nsince type constructors fall back to convert methods.\u001b[39m",
+      "",
+      "Stacktrace:",
+      " [1] \u001b[1minclude_string\u001b[22m\u001b[22m\u001b[1m(\u001b[22m\u001b[22m::String, ::String\u001b[1m)\u001b[22m\u001b[22m at \u001b[1m./loading.jl:515\u001b[22m\u001b[22m"
+     ]
+    }
+   ],
    "source": [
     "v.a = \"This won't work because I'm a string\""
    ]
@@ -262,11 +369,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "add_field_values_many_times (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "function add_field_values_many_times(m)\n",
     "    z = 0.0\n",
@@ -285,11 +401,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0.000170 seconds (10.09 k allocations: 162.717 KiB)\n"
+     ]
+    }
+   ],
    "source": [
     "add_field_values_many_times(MyType(10.0))\n",
     "@time add_field_values_many_times(MyType(10.0))"
@@ -297,11 +419,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0.000007 seconds (5 allocations: 176 bytes)\n"
+     ]
+    }
+   ],
    "source": [
     "add_field_values_many_times(MyType2(10.0))\n",
     "@time add_field_values_many_times(MyType2(10.0))"
@@ -327,7 +455,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {
     "collapsed": true
    },
@@ -347,55 +475,101 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Euro(10.0)"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "e = Euro(10)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "LoadError",
+     "evalue": "\u001b[91mtype Euro is immutable\u001b[39m",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[91mtype Euro is immutable\u001b[39m",
+      "",
+      "Stacktrace:",
+      " [1] \u001b[1minclude_string\u001b[22m\u001b[22m\u001b[1m(\u001b[22m\u001b[22m::String, ::String\u001b[1m)\u001b[22m\u001b[22m at \u001b[1m./loading.jl:515\u001b[22m\u001b[22m"
+     ]
+    }
+   ],
    "source": [
     "e.val = 12        # No can do - the object is immutable"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "10.0"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "e.val"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Float64"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "typeof(e.val)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Euro"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "typeof(e)"
    ]
@@ -418,13 +592,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 108,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "160"
+      ]
+     },
+     "execution_count": 108,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "float_list = Array(Float64, 20)\n",
+    "float_list = Array{Float64}(20)\n",
     "sizeof(float_list)"
    ]
   },
@@ -437,13 +620,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 109,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "160"
+      ]
+     },
+     "execution_count": 109,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "euro_list = Array(Euro, 20)\n",
+    "euro_list = Array{Euro}(20)\n",
     "sizeof(euro_list)"
    ]
   },
@@ -467,7 +659,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {
     "collapsed": true
    },
@@ -479,33 +671,60 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "IAmEmpty()"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "e = IAmEmpty()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "IAmEmpty()"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "f = IAmEmpty()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "true"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "e==f"
    ]
@@ -544,22 +763,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "value (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "value(e::Euro) = e.val"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "10.0"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "e = Euro(10)\n",
     "value(e)"
@@ -590,11 +827,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "value (generic function with 2 methods)"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "immutable Car\n",
     "    price :: Float64\n",
@@ -605,11 +851,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "500.0"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "c = Car(500)\n",
     "value(c)"
@@ -640,11 +895,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "show (generic function with 268 methods)"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import Base: show\n",
     "\n",
@@ -653,22 +917,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.0 €"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "Euro(3)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.14 €"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "Euro(pi)"
    ]
@@ -684,11 +966,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "+ (generic function with 181 methods)"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import Base: +\n",
     "\n",
@@ -697,11 +988,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5.0 €"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "a = Euro(2)\n",
     "b = Euro(3)\n",
@@ -717,11 +1017,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5.0 €"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "sum([a b])"
    ]
@@ -735,11 +1044,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0.000006 seconds (5 allocations: 176 bytes)\n",
+      "  0.000007 seconds (5 allocations: 176 bytes)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "5026.03 €"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "N = 10000\n",
     "float_list = rand(N)\n",
@@ -770,11 +1096,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "my_sum (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "function my_sum(a)\n",
     "    z = a[1]\n",
@@ -787,11 +1122,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0.000009 seconds (5 allocations: 176 bytes)\n",
+      "  0.000037 seconds (5 allocations: 176 bytes)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "5026.03 €"
+      ]
+     },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "s3 = my_sum(euro_list)\n",
     "@time sum(float_list)\n",
@@ -825,11 +1177,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "* (generic function with 183 methods)"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import Base: *\n",
     "\n",
@@ -838,11 +1199,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4.0 €"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "2*Euro(2)"
    ]
@@ -876,11 +1246,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "my_sum_slow (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "function my_sum_slow(a)\n",
     "    z = 0\n",
@@ -893,11 +1272,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0.000013 seconds (5 allocations: 176 bytes)\n",
+      "  0.000379 seconds (30.00 k allocations: 468.906 KiB)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "5026.033565679057"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "s4 = my_sum_slow(float_list)\n",
     "@time sum(float_list)\n",
@@ -917,11 +1313,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "CodeInfo(:(begin \n",
+       "        z = 0 # line 3:\n",
+       "        SSAValue(2) = (Base.arraylen)(a)::Int64\n",
+       "        SSAValue(3) = (Base.select_value)((Base.sle_int)(1, SSAValue(2))::Bool, SSAValue(2), (Base.sub_int)(1, 1)::Int64)::Int64\n",
+       "        #temp#@_4 = 1\n",
+       "        6: \n",
+       "        unless (Base.not_int)((#temp#@_4 === (Base.add_int)(SSAValue(3), 1)::Int64)::Bool)::Bool goto 31\n",
+       "        SSAValue(4) = #temp#@_4\n",
+       "        SSAValue(5) = (Base.add_int)(#temp#@_4, 1)::Int64\n",
+       "        i = SSAValue(4)\n",
+       "        #temp#@_4 = SSAValue(5) # line 4:\n",
+       "        unless (z isa Int64)::Bool goto 16\n",
+       "        #temp#@_6 = MethodInstance for +(::Int64, ::Float64)\n",
+       "        goto 25\n",
+       "        16: \n",
+       "        unless (z isa Float64)::Bool goto 20\n",
+       "        #temp#@_6 = MethodInstance for +(::Float64, ::Float64)\n",
+       "        goto 25\n",
+       "        20: \n",
+       "        goto 22\n",
+       "        22: \n",
+       "        #temp#@_7 = (z + (Base.arrayref)(a, i)::Float64)::Float64\n",
+       "        goto 27\n",
+       "        25: \n",
+       "        #temp#@_7 = $(Expr(:invoke, :(#temp#@_6), :(Main.+), :(z), :((Base.arrayref)(a, i)::Float64)))\n",
+       "        27: \n",
+       "        z = #temp#@_7\n",
+       "        29: \n",
+       "        goto 6\n",
+       "        31:  # line 6:\n",
+       "        return z\n",
+       "    end))=>Union{Float64, Int64}"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "@code_typed my_sum_slow(float_list)"
    ]
@@ -951,11 +1387,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "LoadError",
+     "evalue": "\u001b[91mMethodError: no method matching +(::Int64, ::Euro)\u001b[0m\nClosest candidates are:\n  +(::Any, ::Any, \u001b[91m::Any\u001b[39m, \u001b[91m::Any...\u001b[39m) at operators.jl:424\n  +(\u001b[91m::Euro\u001b[39m, ::Euro) at In[37]:3\n  +(::T<:Union{Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64, UInt8}, \u001b[91m::T<:Union{Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64, UInt8}\u001b[39m) where T<:Union{Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64, UInt8} at int.jl:32\n  ...\u001b[39m",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[91mMethodError: no method matching +(::Int64, ::Euro)\u001b[0m\nClosest candidates are:\n  +(::Any, ::Any, \u001b[91m::Any\u001b[39m, \u001b[91m::Any...\u001b[39m) at operators.jl:424\n  +(\u001b[91m::Euro\u001b[39m, ::Euro) at In[37]:3\n  +(::T<:Union{Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64, UInt8}, \u001b[91m::T<:Union{Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64, UInt8}\u001b[39m) where T<:Union{Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64, UInt8} at int.jl:32\n  ...\u001b[39m",
+      "",
+      "Stacktrace:",
+      " [1] \u001b[1mmy_sum_slow\u001b[22m\u001b[22m\u001b[1m(\u001b[22m\u001b[22m::Array{Euro,1}\u001b[1m)\u001b[22m\u001b[22m at \u001b[1m./In[45]:4\u001b[22m\u001b[22m",
+      " [2] \u001b[1minclude_string\u001b[22m\u001b[22m\u001b[1m(\u001b[22m\u001b[22m::String, ::String\u001b[1m)\u001b[22m\u001b[22m at \u001b[1m./loading.jl:515\u001b[22m\u001b[22m"
+     ]
+    }
+   ],
    "source": [
     "@time my_sum_slow(euro_list)"
    ]
@@ -985,11 +1432,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "my_sum_not_slow_anymore (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 49,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "function my_sum_not_slow_anymore(a)\n",
     "    z::Float64 = 0\n",
@@ -1020,13 +1476,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 110,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0-element Array{BigFloat,1}"
+      ]
+     },
+     "execution_count": 110,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "empty_array = Array(BigFloat,0)"
+    "empty_array = Array{BigFloat}(0)"
    ]
   },
   {
@@ -1038,22 +1503,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 51,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.000000000000000000000000000000000000000000000000000000000000000000000000000000"
+      ]
+     },
+     "execution_count": 51,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "sum(empty_array)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "BigFloat"
+      ]
+     },
+     "execution_count": 52,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "typeof(ans)"
    ]
@@ -1067,55 +1550,102 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "LoadError",
+     "evalue": "\u001b[91mBoundsError: attempt to access 0-element Array{BigFloat,1} at index [1]\u001b[39m",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[91mBoundsError: attempt to access 0-element Array{BigFloat,1} at index [1]\u001b[39m",
+      "",
+      "Stacktrace:",
+      " [1] \u001b[1mmy_sum\u001b[22m\u001b[22m\u001b[1m(\u001b[22m\u001b[22m::Array{BigFloat,1}\u001b[1m)\u001b[22m\u001b[22m at \u001b[1m./In[41]:2\u001b[22m\u001b[22m",
+      " [2] \u001b[1minclude_string\u001b[22m\u001b[22m\u001b[1m(\u001b[22m\u001b[22m::String, ::String\u001b[1m)\u001b[22m\u001b[22m at \u001b[1m./loading.jl:515\u001b[22m\u001b[22m"
+     ]
+    }
+   ],
    "source": [
     "my_sum(empty_array)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 54,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 54,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "my_sum_slow(empty_array)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Int64"
+      ]
+     },
+     "execution_count": 55,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "typeof(ans)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 56,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.0"
+      ]
+     },
+     "execution_count": 56,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "my_sum_not_slow_anymore(empty_array)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 57,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Float64"
+      ]
+     },
+     "execution_count": 57,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "typeof(ans)"
    ]
@@ -1159,22 +1689,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 111,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4-element Array{Float64,1}:\n",
+       " 6.91847e-310\n",
+       " 6.91847e-310\n",
+       " 6.91847e-310\n",
+       " 6.91847e-310"
+      ]
+     },
+     "execution_count": 111,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "a = Array(Float64, 4)"
+    "a = Array{Float64}(4)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 59,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Array{Float64,1}"
+      ]
+     },
+     "execution_count": 59,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "typeof(a)"
    ]
@@ -1190,10 +1742,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 60,
+   "metadata": {},
    "outputs": [],
    "source": [
     "immutable Point{T}\n",
@@ -1205,11 +1755,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 61,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Point{Float64}(0.1, 0.2, 0.4)"
+      ]
+     },
+     "execution_count": 61,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "p = Point(0.1, 0.2, 0.4)"
    ]
@@ -1223,22 +1782,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 62,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Point{Float64}"
+      ]
+     },
+     "execution_count": 62,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "typeof(p)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 63,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.1"
+      ]
+     },
+     "execution_count": 63,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "p.x"
    ]
@@ -1277,11 +1854,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 64,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "my_sum2 (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 64,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "function my_sum2{T}(a::Array{T})\n",
     "    z = zero(T)\n",
@@ -1303,35 +1889,62 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 65,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5"
+      ]
+     },
+     "execution_count": 65,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "my_sum2([2 3])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 66,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5.0"
+      ]
+     },
+     "execution_count": 66,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "my_sum2([2.0 3.0])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 112,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.000000000000000000000000000000000000000000000000000000000000000000000000000000"
+      ]
+     },
+     "execution_count": 112,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "my_sum2(Array(BigFloat, 0))"
+    "my_sum2(Array{BigFloat}(0))"
    ]
   },
   {
@@ -1347,11 +1960,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 68,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "zero (generic function with 16 methods)"
+      ]
+     },
+     "execution_count": 68,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import Base: zero\n",
     "\n",
@@ -1360,22 +1982,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 113,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.0 €"
+      ]
+     },
+     "execution_count": 113,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "my_sum2(Array(Euro, 0))"
+    "my_sum2(Array{Euro}( 0))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 70,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5.0 €"
+      ]
+     },
+     "execution_count": 70,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "my_sum2([Euro(2) Euro(3)])"
    ]
@@ -1389,22 +2029,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 71,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DataType"
+      ]
+     },
+     "execution_count": 71,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "typeof(Float64)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 72,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DataType"
+      ]
+     },
+     "execution_count": 72,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "typeof(Euro)"
    ]
@@ -1418,11 +2076,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 73,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DataType"
+      ]
+     },
+     "execution_count": 73,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "typeof(DataType)"
    ]
@@ -1454,13 +2121,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 115,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "abstract AbstractPoint"
+    "abstract type AbstractPoint\n",
+    "end"
    ]
   },
   {
@@ -1474,10 +2140,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 75,
+   "metadata": {},
    "outputs": [],
    "source": [
     "immutable Point2d <: AbstractPoint\n",
@@ -1488,10 +2152,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 76,
+   "metadata": {},
    "outputs": [],
    "source": [
     "immutable Point3d <: AbstractPoint\n",
@@ -1503,55 +2165,102 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 77,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Point2d(0.1, 2.0)"
+      ]
+     },
+     "execution_count": 77,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "p2 = Point2d(0.1, 2.0)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 78,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Point2d"
+      ]
+     },
+     "execution_count": 78,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "typeof(p2)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 79,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "LoadError",
+     "evalue": "\u001b[91mUndefVarError: super not defined\u001b[39m",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[91mUndefVarError: super not defined\u001b[39m",
+      "",
+      "Stacktrace:",
+      " [1] \u001b[1minclude_string\u001b[22m\u001b[22m\u001b[1m(\u001b[22m\u001b[22m::String, ::String\u001b[1m)\u001b[22m\u001b[22m at \u001b[1m./loading.jl:515\u001b[22m\u001b[22m"
+     ]
+    }
+   ],
    "source": [
     "super(Point2d)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 80,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Point3d(5.0, 7.2, 4.0)"
+      ]
+     },
+     "execution_count": 80,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "p3 = Point3d(5.0, 7.2, 4)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 81,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "LoadError",
+     "evalue": "\u001b[91mUndefVarError: super not defined\u001b[39m",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[91mUndefVarError: super not defined\u001b[39m",
+      "",
+      "Stacktrace:",
+      " [1] \u001b[1minclude_string\u001b[22m\u001b[22m\u001b[1m(\u001b[22m\u001b[22m::String, ::String\u001b[1m)\u001b[22m\u001b[22m at \u001b[1m./loading.jl:515\u001b[22m\u001b[22m"
+     ]
+    }
+   ],
    "source": [
     "super(Point3d)"
    ]
@@ -1574,11 +2283,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 82,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "LoadError",
+     "evalue": "\u001b[91minvalid subtyping in definition of Point2d_with_unit_norm\u001b[39m",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[91minvalid subtyping in definition of Point2d_with_unit_norm\u001b[39m",
+      "",
+      "Stacktrace:",
+      " [1] \u001b[1minclude_string\u001b[22m\u001b[22m\u001b[1m(\u001b[22m\u001b[22m::String, ::String\u001b[1m)\u001b[22m\u001b[22m at \u001b[1m./loading.jl:515\u001b[22m\u001b[22m"
+     ]
+    }
+   ],
    "source": [
     "type Point2d_with_unit_norm <: Point2d\n",
     "end"
@@ -1615,22 +2334,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 83,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "first_dimension (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 83,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "first_dimension(p::AbstractPoint) = p.x"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 84,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.1"
+      ]
+     },
+     "execution_count": 84,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "p2 = Point2d(0.1, 2.0)\n",
     "first_dimension(p2)"
@@ -1638,11 +2375,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 85,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5.0"
+      ]
+     },
+     "execution_count": 85,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "p3 = Point3d(5.0, 7.2, 4)\n",
     "first_dimension(p3)"
@@ -1669,33 +2415,60 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 86,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "second_dimension (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 86,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "second_dimension(p) = p.y"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 87,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2.0"
+      ]
+     },
+     "execution_count": 87,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "second_dimension(p2)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 88,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "7.2"
+      ]
+     },
+     "execution_count": 88,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "second_dimension(p3)"
    ]
@@ -1720,11 +2493,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 89,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "second_dimension (generic function with 2 methods)"
+      ]
+     },
+     "execution_count": 89,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "type EinsteinianSpacetime\n",
     "    space1\n",
@@ -1817,77 +2599,140 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 90,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "8"
+      ]
+     },
+     "execution_count": 90,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "sizeof(Float64)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 91,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4"
+      ]
+     },
+     "execution_count": 91,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "sizeof(Float32)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 92,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 92,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "sizeof(Float16)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 93,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "8"
+      ]
+     },
+     "execution_count": 93,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "sizeof(Int64)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 94,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4"
+      ]
+     },
+     "execution_count": 94,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "sizeof(Int32)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 95,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 95,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "sizeof(Int16)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 96,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "8"
+      ]
+     },
+     "execution_count": 96,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "sizeof(UInt64)"
    ]
@@ -1895,9 +2740,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   },
@@ -1910,99 +2753,82 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 116,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AbstractFloat"
+      ]
+     },
+     "execution_count": 116,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "super(Float64)"
+    "supertype(Float64)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 117,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Real"
+      ]
+     },
+     "execution_count": 117,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "super(AbstractFloat)"
+    "supertype(AbstractFloat)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 118,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Number"
+      ]
+     },
+     "execution_count": 118,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "super(Real)"
+    "supertype(Real)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 119,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Any"
+      ]
+     },
+     "execution_count": 119,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "super(Number)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "super(Int64)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "super(Signed)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "super(Integer)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "super(Real)"
+    "supertype(Number)"
    ]
   },
   {
@@ -2016,24 +2842,131 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 120,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Signed"
+      ]
+     },
+     "execution_count": 120,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "super(UInt64)"
+    "supertype(Int64)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 121,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Integer"
+      ]
+     },
+     "execution_count": 121,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "supertype(Signed)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 122,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Real"
+      ]
+     },
+     "execution_count": 122,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "supertype(Integer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 123,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Number"
+      ]
+     },
+     "execution_count": 123,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "supertype(Real)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 124,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Unsigned"
+      ]
+     },
+     "execution_count": 124,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "super(Unsigned)"
+    "supertype(UInt64)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 125,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Integer"
+      ]
+     },
+     "execution_count": 125,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "supertype(Unsigned)"
    ]
   },
   {
@@ -2056,11 +2989,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 107,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "square (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 107,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "square(x::Number) = x*x"
    ]
@@ -2093,17 +3035,17 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 0.4.0",
+   "display_name": "Julia 0.6.0",
    "language": "julia",
-   "name": "julia-0.4"
+   "name": "julia-0.6"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "0.4.0"
+   "version": "0.6.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/Chapter3_Dispatch.ipynb
+++ b/Chapter3_Dispatch.ipynb
@@ -48,22 +48,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "action (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "action(x::Integer) = \"Acting on Integer\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "action (generic function with 2 methods)"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "action(x::AbstractFloat) = \"Acting on AbstractFloat\""
    ]
@@ -77,22 +95,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"Acting on Integer\""
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "action(1)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"Acting on AbstractFloat\""
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "action(1.0)"
    ]
@@ -106,33 +142,71 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "2 methods for generic function <b>action</b>:<ul><li> action(x::<b>Integer</b>) at In[1]:1</li> <li> action(x::<b>AbstractFloat</b>) at In[2]:1</li> </ul>"
+      ],
+      "text/plain": [
+       "# 2 methods for generic function \"action\":\n",
+       "action(x::Integer) in Main at In[1]:1\n",
+       "action(x::AbstractFloat) in Main at In[2]:1"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "methods(action)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "action(x::<b>Integer</b>) at In[1]:1"
+      ],
+      "text/plain": [
+       "action(x::Integer) in Main at In[1]:1"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "@which action(1)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "action(x::<b>AbstractFloat</b>) at In[2]:1"
+      ],
+      "text/plain": [
+       "action(x::AbstractFloat) in Main at In[2]:1"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "@which action(1.0)"
    ]
@@ -153,44 +227,86 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "action (generic function with 3 methods)"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "action(x::Int32) = \"For Int32 I have a better algorithm\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "3 methods for generic function <b>action</b>:<ul><li> action(x::<b>Int32</b>) at In[8]:1</li> <li> action(x::<b>Integer</b>) at In[1]:1</li> <li> action(x::<b>AbstractFloat</b>) at In[2]:1</li> </ul>"
+      ],
+      "text/plain": [
+       "# 3 methods for generic function \"action\":\n",
+       "action(x::Int32) in Main at In[8]:1\n",
+       "action(x::Integer) in Main at In[1]:1\n",
+       "action(x::AbstractFloat) in Main at In[2]:1"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "methods(action)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"Acting on Integer\""
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "action(1)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"For Int32 I have a better algorithm\""
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "action(Int32(1))"
    ]
@@ -220,11 +336,203 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "180 methods for generic function <b>+</b>:<ul><li> +(x::<b>Bool</b>, z::<b>Complex{Bool}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/complex.jl#L232\" target=\"_blank\">complex.jl:232</a></li> <li> +(x::<b>Bool</b>, y::<b>Bool</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/bool.jl#L89\" target=\"_blank\">bool.jl:89</a></li> <li> +(x::<b>Bool</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/bool.jl#L86\" target=\"_blank\">bool.jl:86</a></li> <li> +<i>{T<:AbstractFloat}</i>(x::<b>Bool</b>, y::<b>T</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/bool.jl#L96\" target=\"_blank\">bool.jl:96</a></li> <li> +(x::<b>Bool</b>, z::<b>Complex</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/complex.jl#L239\" target=\"_blank\">complex.jl:239</a></li> <li> +(a::<b>Float16</b>, b::<b>Float16</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/float.jl#L372\" target=\"_blank\">float.jl:372</a></li> <li> +(x::<b>Float32</b>, y::<b>Float32</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/float.jl#L374\" target=\"_blank\">float.jl:374</a></li> <li> +(x::<b>Float64</b>, y::<b>Float64</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/float.jl#L375\" target=\"_blank\">float.jl:375</a></li> <li> +(z::<b>Complex{Bool}</b>, x::<b>Bool</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/complex.jl#L233\" target=\"_blank\">complex.jl:233</a></li> <li> +(z::<b>Complex{Bool}</b>, x::<b>Real</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/complex.jl#L247\" target=\"_blank\">complex.jl:247</a></li> <li> +(x::<b>Char</b>, y::<b>Integer</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/char.jl#L40\" target=\"_blank\">char.jl:40</a></li> <li> +(c::<b>BigInt</b>, x::<b>BigFloat</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/mpfr.jl#L312\" target=\"_blank\">mpfr.jl:312</a></li> <li> +(a::<b>BigInt</b>, b::<b>BigInt</b>, c::<b>BigInt</b>, d::<b>BigInt</b>, e::<b>BigInt</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/gmp.jl#L334\" target=\"_blank\">gmp.jl:334</a></li> <li> +(a::<b>BigInt</b>, b::<b>BigInt</b>, c::<b>BigInt</b>, d::<b>BigInt</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/gmp.jl#L327\" target=\"_blank\">gmp.jl:327</a></li> <li> +(a::<b>BigInt</b>, b::<b>BigInt</b>, c::<b>BigInt</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/gmp.jl#L321\" target=\"_blank\">gmp.jl:321</a></li> <li> +(x::<b>BigInt</b>, y::<b>BigInt</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/gmp.jl#L289\" target=\"_blank\">gmp.jl:289</a></li> <li> +(x::<b>BigInt</b>, c::<b>Union{UInt16, UInt32, UInt64, UInt8}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/gmp.jl#L346\" target=\"_blank\">gmp.jl:346</a></li> <li> +(x::<b>BigInt</b>, c::<b>Union{Int16, Int32, Int64, Int8}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/gmp.jl#L362\" target=\"_blank\">gmp.jl:362</a></li> <li> +(a::<b>BigFloat</b>, b::<b>BigFloat</b>, c::<b>BigFloat</b>, d::<b>BigFloat</b>, e::<b>BigFloat</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/mpfr.jl#L460\" target=\"_blank\">mpfr.jl:460</a></li> <li> +(a::<b>BigFloat</b>, b::<b>BigFloat</b>, c::<b>BigFloat</b>, d::<b>BigFloat</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/mpfr.jl#L453\" target=\"_blank\">mpfr.jl:453</a></li> <li> +(a::<b>BigFloat</b>, b::<b>BigFloat</b>, c::<b>BigFloat</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/mpfr.jl#L447\" target=\"_blank\">mpfr.jl:447</a></li> <li> +(x::<b>BigFloat</b>, c::<b>BigInt</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/mpfr.jl#L308\" target=\"_blank\">mpfr.jl:308</a></li> <li> +(x::<b>BigFloat</b>, y::<b>BigFloat</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/mpfr.jl#L277\" target=\"_blank\">mpfr.jl:277</a></li> <li> +(x::<b>BigFloat</b>, c::<b>Union{UInt16, UInt32, UInt64, UInt8}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/mpfr.jl#L284\" target=\"_blank\">mpfr.jl:284</a></li> <li> +(x::<b>BigFloat</b>, c::<b>Union{Int16, Int32, Int64, Int8}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/mpfr.jl#L292\" target=\"_blank\">mpfr.jl:292</a></li> <li> +(x::<b>BigFloat</b>, c::<b>Union{Float16, Float32, Float64}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/mpfr.jl#L300\" target=\"_blank\">mpfr.jl:300</a></li> <li> +(B::<b>BitArray{2}</b>, J::<b>UniformScaling</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/uniformscaling.jl#L59\" target=\"_blank\">linalg/uniformscaling.jl:59</a></li> <li> +(a::<b>Base.Pkg.Resolve.VersionWeights.VWPreBuildItem</b>, b::<b>Base.Pkg.Resolve.VersionWeights.VWPreBuildItem</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/pkg/resolve/versionweight.jl#L87\" target=\"_blank\">pkg/resolve/versionweight.jl:87</a></li> <li> +(a::<b>Base.Pkg.Resolve.VersionWeights.VWPreBuild</b>, b::<b>Base.Pkg.Resolve.VersionWeights.VWPreBuild</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/pkg/resolve/versionweight.jl#L135\" target=\"_blank\">pkg/resolve/versionweight.jl:135</a></li> <li> +(a::<b>Base.Pkg.Resolve.VersionWeights.VersionWeight</b>, b::<b>Base.Pkg.Resolve.VersionWeights.VersionWeight</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/pkg/resolve/versionweight.jl#L197\" target=\"_blank\">pkg/resolve/versionweight.jl:197</a></li> <li> +(a::<b>Base.Pkg.Resolve.MaxSum.FieldValues.FieldValue</b>, b::<b>Base.Pkg.Resolve.MaxSum.FieldValues.FieldValue</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/pkg/resolve/fieldvalue.jl#L44\" target=\"_blank\">pkg/resolve/fieldvalue.jl:44</a></li> <li> +(x::<b>Base.Dates.CompoundPeriod</b>, y::<b>Base.Dates.CompoundPeriod</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/periods.jl#L349\" target=\"_blank\">dates/periods.jl:349</a></li> <li> +(x::<b>Base.Dates.CompoundPeriod</b>, y::<b>Base.Dates.Period</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/periods.jl#L347\" target=\"_blank\">dates/periods.jl:347</a></li> <li> +(x::<b>Base.Dates.CompoundPeriod</b>, y::<b>Base.Dates.TimeType</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/periods.jl#L387\" target=\"_blank\">dates/periods.jl:387</a></li> <li> +(x::<b>Date</b>, y::<b>Base.Dates.Day</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L77\" target=\"_blank\">dates/arithmetic.jl:77</a></li> <li> +(x::<b>Date</b>, y::<b>Base.Dates.Week</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L75\" target=\"_blank\">dates/arithmetic.jl:75</a></li> <li> +(dt::<b>Date</b>, z::<b>Base.Dates.Month</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L58\" target=\"_blank\">dates/arithmetic.jl:58</a></li> <li> +(dt::<b>Date</b>, y::<b>Base.Dates.Year</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L32\" target=\"_blank\">dates/arithmetic.jl:32</a></li> <li> +(dt::<b>Date</b>, t::<b>Base.Dates.Time</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L20\" target=\"_blank\">dates/arithmetic.jl:20</a></li> <li> +(t::<b>Base.Dates.Time</b>, dt::<b>Date</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L24\" target=\"_blank\">dates/arithmetic.jl:24</a></li> <li> +(x::<b>Base.Dates.Time</b>, y::<b>Base.Dates.TimePeriod</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L81\" target=\"_blank\">dates/arithmetic.jl:81</a></li> <li> +(dt::<b>DateTime</b>, z::<b>Base.Dates.Month</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L52\" target=\"_blank\">dates/arithmetic.jl:52</a></li> <li> +(dt::<b>DateTime</b>, y::<b>Base.Dates.Year</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L28\" target=\"_blank\">dates/arithmetic.jl:28</a></li> <li> +(x::<b>DateTime</b>, y::<b>Base.Dates.Period</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L79\" target=\"_blank\">dates/arithmetic.jl:79</a></li> <li> +(y::<b>AbstractFloat</b>, x::<b>Bool</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/bool.jl#L98\" target=\"_blank\">bool.jl:98</a></li> <li> +<i>{T<:Union{Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64, UInt8}}</i>(x::<b>T</b>, y::<b>T</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/int.jl#L32\" target=\"_blank\">int.jl:32</a></li> <li> +(x::<b>Integer</b>, y::<b>Ptr</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/pointer.jl#L128\" target=\"_blank\">pointer.jl:128</a></li> <li> +(z::<b>Complex</b>, w::<b>Complex</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/complex.jl#L221\" target=\"_blank\">complex.jl:221</a></li> <li> +(z::<b>Complex</b>, x::<b>Bool</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/complex.jl#L240\" target=\"_blank\">complex.jl:240</a></li> <li> +(x::<b>Real</b>, z::<b>Complex{Bool}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/complex.jl#L246\" target=\"_blank\">complex.jl:246</a></li> <li> +(x::<b>Real</b>, z::<b>Complex</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/complex.jl#L258\" target=\"_blank\">complex.jl:258</a></li> <li> +(z::<b>Complex</b>, x::<b>Real</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/complex.jl#L259\" target=\"_blank\">complex.jl:259</a></li> <li> +(x::<b>Rational</b>, y::<b>Rational</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/rational.jl#L245\" target=\"_blank\">rational.jl:245</a></li> <li> +(x::<b>Integer</b>, y::<b>Char</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/char.jl#L41\" target=\"_blank\">char.jl:41</a></li> <li> +(i::<b>Integer</b>, index::<b>CartesianIndex</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/multidimensional.jl#L79\" target=\"_blank\">multidimensional.jl:79</a></li> <li> +(c::<b>Union{UInt16, UInt32, UInt64, UInt8}</b>, x::<b>BigInt</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/gmp.jl#L350\" target=\"_blank\">gmp.jl:350</a></li> <li> +(c::<b>Union{Int16, Int32, Int64, Int8}</b>, x::<b>BigInt</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/gmp.jl#L363\" target=\"_blank\">gmp.jl:363</a></li> <li> +(c::<b>Union{UInt16, UInt32, UInt64, UInt8}</b>, x::<b>BigFloat</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/mpfr.jl#L288\" target=\"_blank\">mpfr.jl:288</a></li> <li> +(c::<b>Union{Int16, Int32, Int64, Int8}</b>, x::<b>BigFloat</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/mpfr.jl#L296\" target=\"_blank\">mpfr.jl:296</a></li> <li> +(c::<b>Union{Float16, Float32, Float64}</b>, x::<b>BigFloat</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/mpfr.jl#L304\" target=\"_blank\">mpfr.jl:304</a></li> <li> +(x::<b>Irrational</b>, y::<b>Irrational</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/irrationals.jl#L109\" target=\"_blank\">irrationals.jl:109</a></li> <li> +(x::<b>Real</b>, r::<b>Base.Use_StepRangeLen_Instead</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/deprecated.jl#L1223\" target=\"_blank\">deprecated.jl:1223</a></li> <li> +(x::<b>Number</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/operators.jl#L399\" target=\"_blank\">operators.jl:399</a></li> <li> +<i>{T<:Number}</i>(x::<b>T</b>, y::<b>T</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/promotion.jl#L335\" target=\"_blank\">promotion.jl:335</a></li> <li> +(x::<b>Number</b>, y::<b>Number</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/promotion.jl#L249\" target=\"_blank\">promotion.jl:249</a></li> <li> +(x::<b>Real</b>, r::<b>AbstractUnitRange</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/range.jl#L721\" target=\"_blank\">range.jl:721</a></li> <li> +(x::<b>Number</b>, r::<b>AbstractUnitRange</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/range.jl#L723\" target=\"_blank\">range.jl:723</a></li> <li> +(x::<b>Number</b>, r::<b>StepRangeLen</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/range.jl#L726\" target=\"_blank\">range.jl:726</a></li> <li> +(x::<b>Number</b>, r::<b>LinSpace</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/range.jl#L730\" target=\"_blank\">range.jl:730</a></li> <li> +(x::<b>Number</b>, r::<b>Range</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/range.jl#L724\" target=\"_blank\">range.jl:724</a></li> <li> +(r::<b>Range</b>, x::<b>Number</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/range.jl#L732\" target=\"_blank\">range.jl:732</a></li> <li> +(r1::<b>OrdinalRange</b>, r2::<b>OrdinalRange</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/range.jl#L882\" target=\"_blank\">range.jl:882</a></li> <li> +<i>{T}</i>(r1::<b>LinSpace{T}</b>, r2::<b>LinSpace{T}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/range.jl#L889\" target=\"_blank\">range.jl:889</a></li> <li> +<i>{R<:Base.TwicePrecision, T}</i>(r1::<b>StepRangeLen{T,R,S} where S</b>, r2::<b>StepRangeLen{T,R,S} where S</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/twiceprecision.jl#L300\" target=\"_blank\">twiceprecision.jl:300</a></li> <li> +<i>{T, S}</i>(r1::<b>StepRangeLen{T,S,S} where S</b>, r2::<b>StepRangeLen{T,S,S} where S</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/range.jl#L905\" target=\"_blank\">range.jl:905</a></li> <li> +(r1::<b>Union{LinSpace, OrdinalRange, StepRangeLen}</b>, r2::<b>Union{LinSpace, OrdinalRange, StepRangeLen}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/range.jl#L896\" target=\"_blank\">range.jl:896</a></li> <li> +(x::<b>Base.TwicePrecision</b>, y::<b>Number</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/twiceprecision.jl#L454\" target=\"_blank\">twiceprecision.jl:454</a></li> <li> +(x::<b>Number</b>, y::<b>Base.TwicePrecision</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/twiceprecision.jl#L457\" target=\"_blank\">twiceprecision.jl:457</a></li> <li> +<i>{T}</i>(x::<b>Base.TwicePrecision{T}</b>, y::<b>Base.TwicePrecision{T}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/twiceprecision.jl#L460\" target=\"_blank\">twiceprecision.jl:460</a></li> <li> +(x::<b>Base.TwicePrecision</b>, y::<b>Base.TwicePrecision</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/twiceprecision.jl#L464\" target=\"_blank\">twiceprecision.jl:464</a></li> <li> +(x::<b>Ptr</b>, y::<b>Integer</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/pointer.jl#L126\" target=\"_blank\">pointer.jl:126</a></li> <li> +(A::<b>BitArray</b>, B::<b>BitArray</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/bitarray.jl#L1176\" target=\"_blank\">bitarray.jl:1176</a></li> <li> +(A::<b>SymTridiagonal</b>, B::<b>SymTridiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/tridiag.jl#L128\" target=\"_blank\">linalg/tridiag.jl:128</a></li> <li> +(A::<b>Tridiagonal</b>, B::<b>Tridiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/tridiag.jl#L624\" target=\"_blank\">linalg/tridiag.jl:624</a></li> <li> +(A::<b>UpperTriangular</b>, B::<b>UpperTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/triangular.jl#L374\" target=\"_blank\">linalg/triangular.jl:374</a></li> <li> +(A::<b>LowerTriangular</b>, B::<b>LowerTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/triangular.jl#L375\" target=\"_blank\">linalg/triangular.jl:375</a></li> <li> +(A::<b>UpperTriangular</b>, B::<b>Base.LinAlg.UnitUpperTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/triangular.jl#L376\" target=\"_blank\">linalg/triangular.jl:376</a></li> <li> +(A::<b>LowerTriangular</b>, B::<b>Base.LinAlg.UnitLowerTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/triangular.jl#L377\" target=\"_blank\">linalg/triangular.jl:377</a></li> <li> +(A::<b>Base.LinAlg.UnitUpperTriangular</b>, B::<b>UpperTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/triangular.jl#L378\" target=\"_blank\">linalg/triangular.jl:378</a></li> <li> +(A::<b>Base.LinAlg.UnitLowerTriangular</b>, B::<b>LowerTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/triangular.jl#L379\" target=\"_blank\">linalg/triangular.jl:379</a></li> <li> +(A::<b>Base.LinAlg.UnitUpperTriangular</b>, B::<b>Base.LinAlg.UnitUpperTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/triangular.jl#L380\" target=\"_blank\">linalg/triangular.jl:380</a></li> <li> +(A::<b>Base.LinAlg.UnitLowerTriangular</b>, B::<b>Base.LinAlg.UnitLowerTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/triangular.jl#L381\" target=\"_blank\">linalg/triangular.jl:381</a></li> <li> +(A::<b>Base.LinAlg.AbstractTriangular</b>, B::<b>Base.LinAlg.AbstractTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/triangular.jl#L382\" target=\"_blank\">linalg/triangular.jl:382</a></li> <li> +(A::<b>Symmetric</b>, x::<b>Bool</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/symmetric.jl#L272\" target=\"_blank\">linalg/symmetric.jl:272</a></li> <li> +(A::<b>Symmetric</b>, x::<b>Number</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/symmetric.jl#L274\" target=\"_blank\">linalg/symmetric.jl:274</a></li> <li> +(A::<b>Hermitian</b>, x::<b>Bool</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/symmetric.jl#L272\" target=\"_blank\">linalg/symmetric.jl:272</a></li> <li> +(A::<b>Hermitian</b>, x::<b>Real</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/symmetric.jl#L274\" target=\"_blank\">linalg/symmetric.jl:274</a></li> <li> +(Da::<b>Diagonal</b>, Db::<b>Diagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/diagonal.jl#L140\" target=\"_blank\">linalg/diagonal.jl:140</a></li> <li> +(A::<b>Bidiagonal</b>, B::<b>Bidiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/bidiag.jl#L330\" target=\"_blank\">linalg/bidiag.jl:330</a></li> <li> +(UL::<b>UpperTriangular</b>, J::<b>UniformScaling</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/uniformscaling.jl#L72\" target=\"_blank\">linalg/uniformscaling.jl:72</a></li> <li> +(UL::<b>Base.LinAlg.UnitUpperTriangular</b>, J::<b>UniformScaling</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/uniformscaling.jl#L75\" target=\"_blank\">linalg/uniformscaling.jl:75</a></li> <li> +(UL::<b>LowerTriangular</b>, J::<b>UniformScaling</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/uniformscaling.jl#L72\" target=\"_blank\">linalg/uniformscaling.jl:72</a></li> <li> +(UL::<b>Base.LinAlg.UnitLowerTriangular</b>, J::<b>UniformScaling</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/uniformscaling.jl#L75\" target=\"_blank\">linalg/uniformscaling.jl:75</a></li> <li> +(A::<b>Array</b>, B::<b>SparseMatrixCSC</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/sparse/sparsematrix.jl#L1462\" target=\"_blank\">sparse/sparsematrix.jl:1462</a></li> <li> +(x::<b>Union{Base.ReshapedArray{T,1,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{T,1}, SubArray{T,1,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where T</b>, y::<b>AbstractSparseArray{Tv,Ti,1} where Ti where Tv</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/sparse/sparsevector.jl#L1333\" target=\"_blank\">sparse/sparsevector.jl:1333</a></li> <li> +(x::<b>Union{Base.ReshapedArray{#s267,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{#s267,N}, SubArray{#s267,N,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where N where #s267<:Union{Base.Dates.CompoundPeriod, Base.Dates.Period}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/periods.jl#L358\" target=\"_blank\">dates/periods.jl:358</a></li> <li> +(A::<b>SparseMatrixCSC</b>, J::<b>UniformScaling</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/sparse/sparsematrix.jl#L3512\" target=\"_blank\">sparse/sparsematrix.jl:3512</a></li> <li> +<i>{TA, TJ}</i>(A::<b>AbstractArray{TA,2}</b>, J::<b>UniformScaling{TJ}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/uniformscaling.jl#L119\" target=\"_blank\">linalg/uniformscaling.jl:119</a></li> <li> +(A::<b>Diagonal</b>, B::<b>Bidiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L113\" target=\"_blank\">linalg/special.jl:113</a></li> <li> +(A::<b>Bidiagonal</b>, B::<b>Diagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L114\" target=\"_blank\">linalg/special.jl:114</a></li> <li> +(A::<b>Diagonal</b>, B::<b>Tridiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L113\" target=\"_blank\">linalg/special.jl:113</a></li> <li> +(A::<b>Tridiagonal</b>, B::<b>Diagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L114\" target=\"_blank\">linalg/special.jl:114</a></li> <li> +(A::<b>Diagonal</b>, B::<b>Array{T,2} where T</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L113\" target=\"_blank\">linalg/special.jl:113</a></li> <li> +(A::<b>Array{T,2} where T</b>, B::<b>Diagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L114\" target=\"_blank\">linalg/special.jl:114</a></li> <li> +(A::<b>Bidiagonal</b>, B::<b>Tridiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L113\" target=\"_blank\">linalg/special.jl:113</a></li> <li> +(A::<b>Tridiagonal</b>, B::<b>Bidiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L114\" target=\"_blank\">linalg/special.jl:114</a></li> <li> +(A::<b>Bidiagonal</b>, B::<b>Array{T,2} where T</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L113\" target=\"_blank\">linalg/special.jl:113</a></li> <li> +(A::<b>Array{T,2} where T</b>, B::<b>Bidiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L114\" target=\"_blank\">linalg/special.jl:114</a></li> <li> +(A::<b>Tridiagonal</b>, B::<b>Array{T,2} where T</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L113\" target=\"_blank\">linalg/special.jl:113</a></li> <li> +(A::<b>Array{T,2} where T</b>, B::<b>Tridiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L114\" target=\"_blank\">linalg/special.jl:114</a></li> <li> +(A::<b>SymTridiagonal</b>, B::<b>Tridiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L122\" target=\"_blank\">linalg/special.jl:122</a></li> <li> +(A::<b>Tridiagonal</b>, B::<b>SymTridiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L123\" target=\"_blank\">linalg/special.jl:123</a></li> <li> +(A::<b>SymTridiagonal</b>, B::<b>Array{T,2} where T</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L122\" target=\"_blank\">linalg/special.jl:122</a></li> <li> +(A::<b>Array{T,2} where T</b>, B::<b>SymTridiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L123\" target=\"_blank\">linalg/special.jl:123</a></li> <li> +(A::<b>Diagonal</b>, B::<b>SymTridiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L131\" target=\"_blank\">linalg/special.jl:131</a></li> <li> +(A::<b>SymTridiagonal</b>, B::<b>Diagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L132\" target=\"_blank\">linalg/special.jl:132</a></li> <li> +(A::<b>Bidiagonal</b>, B::<b>SymTridiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L131\" target=\"_blank\">linalg/special.jl:131</a></li> <li> +(A::<b>SymTridiagonal</b>, B::<b>Bidiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L132\" target=\"_blank\">linalg/special.jl:132</a></li> <li> +(A::<b>Diagonal</b>, B::<b>UpperTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L143\" target=\"_blank\">linalg/special.jl:143</a></li> <li> +(A::<b>UpperTriangular</b>, B::<b>Diagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L144\" target=\"_blank\">linalg/special.jl:144</a></li> <li> +(A::<b>Diagonal</b>, B::<b>Base.LinAlg.UnitUpperTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L143\" target=\"_blank\">linalg/special.jl:143</a></li> <li> +(A::<b>Base.LinAlg.UnitUpperTriangular</b>, B::<b>Diagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L144\" target=\"_blank\">linalg/special.jl:144</a></li> <li> +(A::<b>Diagonal</b>, B::<b>LowerTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L143\" target=\"_blank\">linalg/special.jl:143</a></li> <li> +(A::<b>LowerTriangular</b>, B::<b>Diagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L144\" target=\"_blank\">linalg/special.jl:144</a></li> <li> +(A::<b>Diagonal</b>, B::<b>Base.LinAlg.UnitLowerTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L143\" target=\"_blank\">linalg/special.jl:143</a></li> <li> +(A::<b>Base.LinAlg.UnitLowerTriangular</b>, B::<b>Diagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L144\" target=\"_blank\">linalg/special.jl:144</a></li> <li> +(A::<b>Base.LinAlg.AbstractTriangular</b>, B::<b>SymTridiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L150\" target=\"_blank\">linalg/special.jl:150</a></li> <li> +(A::<b>SymTridiagonal</b>, B::<b>Base.LinAlg.AbstractTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L151\" target=\"_blank\">linalg/special.jl:151</a></li> <li> +(A::<b>Base.LinAlg.AbstractTriangular</b>, B::<b>Tridiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L150\" target=\"_blank\">linalg/special.jl:150</a></li> <li> +(A::<b>Tridiagonal</b>, B::<b>Base.LinAlg.AbstractTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L151\" target=\"_blank\">linalg/special.jl:151</a></li> <li> +(A::<b>Base.LinAlg.AbstractTriangular</b>, B::<b>Bidiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L150\" target=\"_blank\">linalg/special.jl:150</a></li> <li> +(A::<b>Bidiagonal</b>, B::<b>Base.LinAlg.AbstractTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L151\" target=\"_blank\">linalg/special.jl:151</a></li> <li> +(A::<b>Base.LinAlg.AbstractTriangular</b>, B::<b>Array{T,2} where T</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L150\" target=\"_blank\">linalg/special.jl:150</a></li> <li> +(A::<b>Array{T,2} where T</b>, B::<b>Base.LinAlg.AbstractTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L151\" target=\"_blank\">linalg/special.jl:151</a></li> <li> +(Y::<b>Union{Base.ReshapedArray{#s266,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{#s266,N}, SubArray{#s266,N,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where N where #s266<:Union{Base.Dates.CompoundPeriod, Base.Dates.Period}</b>, x::<b>Union{Base.Dates.CompoundPeriod, Base.Dates.Period}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/periods.jl#L363\" target=\"_blank\">dates/periods.jl:363</a></li> <li> +(X::<b>Union{Base.ReshapedArray{#s265,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{#s265,N}, SubArray{#s265,N,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where N where #s265<:Union{Base.Dates.CompoundPeriod, Base.Dates.Period}</b>, Y::<b>Union{Base.ReshapedArray{#s264,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{#s264,N}, SubArray{#s264,N,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where N where #s264<:Union{Base.Dates.CompoundPeriod, Base.Dates.Period}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/periods.jl#L364\" target=\"_blank\">dates/periods.jl:364</a></li> <li> +(x::<b>Union{Base.ReshapedArray{#s267,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{#s267,N}, SubArray{#s267,N,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where N where #s267<:Union{Base.Dates.CompoundPeriod, Base.Dates.Period}</b>, y::<b>Base.Dates.TimeType</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L86\" target=\"_blank\">dates/arithmetic.jl:86</a></li> <li> +(r::<b>Range{#s267} where #s267<:Base.Dates.TimeType</b>, x::<b>Base.Dates.Period</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/ranges.jl#L47\" target=\"_blank\">dates/ranges.jl:47</a></li> <li> +(A::<b>SparseMatrixCSC</b>, B::<b>SparseMatrixCSC</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/sparse/sparsematrix.jl#L1458\" target=\"_blank\">sparse/sparsematrix.jl:1458</a></li> <li> +(A::<b>SparseMatrixCSC</b>, B::<b>Array</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/sparse/sparsematrix.jl#L1461\" target=\"_blank\">sparse/sparsematrix.jl:1461</a></li> <li> +(x::<b>AbstractSparseArray{Tv,Ti,1} where Ti where Tv</b>, y::<b>AbstractSparseArray{Tv,Ti,1} where Ti where Tv</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/sparse/sparsevector.jl#L1332\" target=\"_blank\">sparse/sparsevector.jl:1332</a></li> <li> +(x::<b>AbstractSparseArray{Tv,Ti,1} where Ti where Tv</b>, y::<b>Union{Base.ReshapedArray{T,1,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{T,1}, SubArray{T,1,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where T</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/sparse/sparsevector.jl#L1334\" target=\"_blank\">sparse/sparsevector.jl:1334</a></li> <li> +(x::<b>AbstractArray{#s45,N} where N where #s45<:Number</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/abstractarraymath.jl#L93\" target=\"_blank\">abstractarraymath.jl:93</a></li> <li> +(A::<b>AbstractArray</b>, B::<b>AbstractArray</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/arraymath.jl#L37\" target=\"_blank\">arraymath.jl:37</a></li> <li> +(A::<b>Number</b>, B::<b>AbstractArray</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/arraymath.jl#L44\" target=\"_blank\">arraymath.jl:44</a></li> <li> +(A::<b>AbstractArray</b>, B::<b>Number</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/arraymath.jl#L47\" target=\"_blank\">arraymath.jl:47</a></li> <li> +<i>{N}</i>(index1::<b>CartesianIndex{N}</b>, index2::<b>CartesianIndex{N}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/multidimensional.jl#L70\" target=\"_blank\">multidimensional.jl:70</a></li> <li> +<i>{N}</i>(index::<b>CartesianIndex{N}</b>, i::<b>Integer</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/multidimensional.jl#L80\" target=\"_blank\">multidimensional.jl:80</a></li> <li> +(J1::<b>UniformScaling</b>, J2::<b>UniformScaling</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/uniformscaling.jl#L58\" target=\"_blank\">linalg/uniformscaling.jl:58</a></li> <li> +(J::<b>UniformScaling</b>, B::<b>BitArray{2}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/uniformscaling.jl#L60\" target=\"_blank\">linalg/uniformscaling.jl:60</a></li> <li> +(J::<b>UniformScaling</b>, A::<b>AbstractArray{T,2} where T</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/uniformscaling.jl#L61\" target=\"_blank\">linalg/uniformscaling.jl:61</a></li> <li> +<i>{T}</i>(a::<b>Base.Pkg.Resolve.VersionWeights.HierarchicalValue{T}</b>, b::<b>Base.Pkg.Resolve.VersionWeights.HierarchicalValue{T}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/pkg/resolve/versionweight.jl#L23\" target=\"_blank\">pkg/resolve/versionweight.jl:23</a></li> <li> +<i>{P<:Base.Dates.Period}</i>(x::<b>P</b>, y::<b>P</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/periods.jl#L70\" target=\"_blank\">dates/periods.jl:70</a></li> <li> +(x::<b>Base.Dates.Period</b>, y::<b>Base.Dates.Period</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/periods.jl#L346\" target=\"_blank\">dates/periods.jl:346</a></li> <li> +(y::<b>Base.Dates.Period</b>, x::<b>Base.Dates.CompoundPeriod</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/periods.jl#L348\" target=\"_blank\">dates/periods.jl:348</a></li> <li> +(x::<b>Union{Base.Dates.CompoundPeriod, Base.Dates.Period}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/periods.jl#L357\" target=\"_blank\">dates/periods.jl:357</a></li> <li> +(x::<b>Union{Base.Dates.CompoundPeriod, Base.Dates.Period}</b>, Y::<b>Union{Base.ReshapedArray{#s267,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{#s267,N}, SubArray{#s267,N,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where N where #s267<:Union{Base.Dates.CompoundPeriod, Base.Dates.Period}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/periods.jl#L362\" target=\"_blank\">dates/periods.jl:362</a></li> <li> +(x::<b>Base.Dates.TimeType</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L8\" target=\"_blank\">dates/arithmetic.jl:8</a></li> <li> +(a::<b>Base.Dates.TimeType</b>, b::<b>Base.Dates.Period</b>, c::<b>Base.Dates.Period</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/periods.jl#L378\" target=\"_blank\">dates/periods.jl:378</a></li> <li> +(a::<b>Base.Dates.TimeType</b>, b::<b>Base.Dates.Period</b>, c::<b>Base.Dates.Period</b>, d::<b>Base.Dates.Period...</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/periods.jl#L379\" target=\"_blank\">dates/periods.jl:379</a></li> <li> +(x::<b>Base.Dates.TimeType</b>, y::<b>Base.Dates.CompoundPeriod</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/periods.jl#L382\" target=\"_blank\">dates/periods.jl:382</a></li> <li> +(x::<b>Base.Dates.Instant</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L4\" target=\"_blank\">dates/arithmetic.jl:4</a></li> <li> +(y::<b>Base.Dates.Period</b>, x::<b>Base.Dates.TimeType</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L83\" target=\"_blank\">dates/arithmetic.jl:83</a></li> <li> +(x::<b>AbstractArray{#s267,N} where N where #s267<:Base.Dates.TimeType</b>, y::<b>Union{Base.Dates.CompoundPeriod, Base.Dates.Period}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L85\" target=\"_blank\">dates/arithmetic.jl:85</a></li> <li> +(x::<b>Base.Dates.Period</b>, r::<b>Range{#s267} where #s267<:Base.Dates.TimeType</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/ranges.jl#L46\" target=\"_blank\">dates/ranges.jl:46</a></li> <li> +(y::<b>Union{Base.Dates.CompoundPeriod, Base.Dates.Period}</b>, x::<b>AbstractArray{#s267,N} where N where #s267<:Base.Dates.TimeType</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L87\" target=\"_blank\">dates/arithmetic.jl:87</a></li> <li> +(y::<b>Base.Dates.TimeType</b>, x::<b>Union{Base.ReshapedArray{#s267,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{#s267,N}, SubArray{#s267,N,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where N where #s267<:Union{Base.Dates.CompoundPeriod, Base.Dates.Period}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L88\" target=\"_blank\">dates/arithmetic.jl:88</a></li> <li> +(J::<b>UniformScaling</b>, x::<b>Number</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/deprecated.jl#L56\" target=\"_blank\">deprecated.jl:56</a></li> <li> +(x::<b>Number</b>, J::<b>UniformScaling</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/deprecated.jl#L56\" target=\"_blank\">deprecated.jl:56</a></li> <li> +(a, b, c, xs...) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/operators.jl#L424\" target=\"_blank\">operators.jl:424</a></li> </ul>"
+      ],
+      "text/plain": [
+       "# 180 methods for generic function \"+\":\n",
+       "+(x::Bool, z::Complex{Bool}) in Base at complex.jl:232\n",
+       "+(x::Bool, y::Bool) in Base at bool.jl:89\n",
+       "+(x::Bool) in Base at bool.jl:86\n",
+       "+(x::Bool, y::T) where T<:AbstractFloat in Base at bool.jl:96\n",
+       "+(x::Bool, z::Complex) in Base at complex.jl:239\n",
+       "+(a::Float16, b::Float16) in Base at float.jl:372\n",
+       "+(x::Float32, y::Float32) in Base at float.jl:374\n",
+       "+(x::Float64, y::Float64) in Base at float.jl:375\n",
+       "+(z::Complex{Bool}, x::Bool) in Base at complex.jl:233\n",
+       "+(z::Complex{Bool}, x::Real) in Base at complex.jl:247\n",
+       "+(x::Char, y::Integer) in Base at char.jl:40\n",
+       "+(c::BigInt, x::BigFloat) in Base.MPFR at mpfr.jl:312\n",
+       "+(a::BigInt, b::BigInt, c::BigInt, d::BigInt, e::BigInt) in Base.GMP at gmp.jl:334\n",
+       "+(a::BigInt, b::BigInt, c::BigInt, d::BigInt) in Base.GMP at gmp.jl:327\n",
+       "+(a::BigInt, b::BigInt, c::BigInt) in Base.GMP at gmp.jl:321\n",
+       "+(x::BigInt, y::BigInt) in Base.GMP at gmp.jl:289\n",
+       "+(x::BigInt, c::Union{UInt16, UInt32, UInt64, UInt8}) in Base.GMP at gmp.jl:346\n",
+       "+(x::BigInt, c::Union{Int16, Int32, Int64, Int8}) in Base.GMP at gmp.jl:362\n",
+       "+(a::BigFloat, b::BigFloat, c::BigFloat, d::BigFloat, e::BigFloat) in Base.MPFR at mpfr.jl:460\n",
+       "+(a::BigFloat, b::BigFloat, c::BigFloat, d::BigFloat) in Base.MPFR at mpfr.jl:453\n",
+       "+(a::BigFloat, b::BigFloat, c::BigFloat) in Base.MPFR at mpfr.jl:447\n",
+       "+(x::BigFloat, c::BigInt) in Base.MPFR at mpfr.jl:308\n",
+       "+(x::BigFloat, y::BigFloat) in Base.MPFR at mpfr.jl:277\n",
+       "+(x::BigFloat, c::Union{UInt16, UInt32, UInt64, UInt8}) in Base.MPFR at mpfr.jl:284\n",
+       "+(x::BigFloat, c::Union{Int16, Int32, Int64, Int8}) in Base.MPFR at mpfr.jl:292\n",
+       "+(x::BigFloat, c::Union{Float16, Float32, Float64}) in Base.MPFR at mpfr.jl:300\n",
+       "+(B::BitArray{2}, J::UniformScaling) in Base.LinAlg at linalg/uniformscaling.jl:59\n",
+       "+(a::Base.Pkg.Resolve.VersionWeights.VWPreBuildItem, b::Base.Pkg.Resolve.VersionWeights.VWPreBuildItem) in Base.Pkg.Resolve.VersionWeights at pkg/resolve/versionweight.jl:87\n",
+       "+(a::Base.Pkg.Resolve.VersionWeights.VWPreBuild, b::Base.Pkg.Resolve.VersionWeights.VWPreBuild) in Base.Pkg.Resolve.VersionWeights at pkg/resolve/versionweight.jl:135\n",
+       "+(a::Base.Pkg.Resolve.VersionWeights.VersionWeight, b::Base.Pkg.Resolve.VersionWeights.VersionWeight) in Base.Pkg.Resolve.VersionWeights at pkg/resolve/versionweight.jl:197\n",
+       "+(a::Base.Pkg.Resolve.MaxSum.FieldValues.FieldValue, b::Base.Pkg.Resolve.MaxSum.FieldValues.FieldValue) in Base.Pkg.Resolve.MaxSum.FieldValues at pkg/resolve/fieldvalue.jl:44\n",
+       "+(x::Base.Dates.CompoundPeriod, y::Base.Dates.CompoundPeriod) in Base.Dates at dates/periods.jl:349\n",
+       "+(x::Base.Dates.CompoundPeriod, y::Base.Dates.Period) in Base.Dates at dates/periods.jl:347\n",
+       "+(x::Base.Dates.CompoundPeriod, y::Base.Dates.TimeType) in Base.Dates at dates/periods.jl:387\n",
+       "+(x::Date, y::Base.Dates.Day) in Base.Dates at dates/arithmetic.jl:77\n",
+       "+(x::Date, y::Base.Dates.Week) in Base.Dates at dates/arithmetic.jl:75\n",
+       "+(dt::Date, z::Base.Dates.Month) in Base.Dates at dates/arithmetic.jl:58\n",
+       "+(dt::Date, y::Base.Dates.Year) in Base.Dates at dates/arithmetic.jl:32\n",
+       "+(dt::Date, t::Base.Dates.Time) in Base.Dates at dates/arithmetic.jl:20\n",
+       "+(t::Base.Dates.Time, dt::Date) in Base.Dates at dates/arithmetic.jl:24\n",
+       "+(x::Base.Dates.Time, y::Base.Dates.TimePeriod) in Base.Dates at dates/arithmetic.jl:81\n",
+       "+(dt::DateTime, z::Base.Dates.Month) in Base.Dates at dates/arithmetic.jl:52\n",
+       "+(dt::DateTime, y::Base.Dates.Year) in Base.Dates at dates/arithmetic.jl:28\n",
+       "+(x::DateTime, y::Base.Dates.Period) in Base.Dates at dates/arithmetic.jl:79\n",
+       "+(y::AbstractFloat, x::Bool) in Base at bool.jl:98\n",
+       "+(x::T, y::T) where T<:Union{Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64, UInt8} in Base at int.jl:32\n",
+       "+(x::Integer, y::Ptr) in Base at pointer.jl:128\n",
+       "+(z::Complex, w::Complex) in Base at complex.jl:221\n",
+       "+(z::Complex, x::Bool) in Base at complex.jl:240\n",
+       "+(x::Real, z::Complex{Bool}) in Base at complex.jl:246\n",
+       "+(x::Real, z::Complex) in Base at complex.jl:258\n",
+       "+(z::Complex, x::Real) in Base at complex.jl:259\n",
+       "+(x::Rational, y::Rational) in Base at rational.jl:245\n",
+       "+(x::Integer, y::Char) in Base at char.jl:41\n",
+       "+(i::Integer, index::CartesianIndex) in Base.IteratorsMD at multidimensional.jl:79\n",
+       "+(c::Union{UInt16, UInt32, UInt64, UInt8}, x::BigInt) in Base.GMP at gmp.jl:350\n",
+       "+(c::Union{Int16, Int32, Int64, Int8}, x::BigInt) in Base.GMP at gmp.jl:363\n",
+       "+(c::Union{UInt16, UInt32, UInt64, UInt8}, x::BigFloat) in Base.MPFR at mpfr.jl:288\n",
+       "+(c::Union{Int16, Int32, Int64, Int8}, x::BigFloat) in Base.MPFR at mpfr.jl:296\n",
+       "+(c::Union{Float16, Float32, Float64}, x::BigFloat) in Base.MPFR at mpfr.jl:304\n",
+       "+(x::Irrational, y::Irrational) in Base at irrationals.jl:109\n",
+       "+(x::Real, r::Base.Use_StepRangeLen_Instead) in Base at deprecated.jl:1223\n",
+       "+(x::Number) in Base at operators.jl:399\n",
+       "+(x::T, y::T) where T<:Number in Base at promotion.jl:335\n",
+       "+(x::Number, y::Number) in Base at promotion.jl:249\n",
+       "+(x::Real, r::AbstractUnitRange) in Base at range.jl:721\n",
+       "+(x::Number, r::AbstractUnitRange) in Base at range.jl:723\n",
+       "+(x::Number, r::StepRangeLen) in Base at range.jl:726\n",
+       "+(x::Number, r::LinSpace) in Base at range.jl:730\n",
+       "+(x::Number, r::Range) in Base at range.jl:724\n",
+       "+(r::Range, x::Number) in Base at range.jl:732\n",
+       "+(r1::OrdinalRange, r2::OrdinalRange) in Base at range.jl:882\n",
+       "+(r1::LinSpace{T}, r2::LinSpace{T}) where T in Base at range.jl:889\n",
+       "+(r1::StepRangeLen{T,R,S} where S, r2::StepRangeLen{T,R,S} where S) where {R<:Base.TwicePrecision, T} in Base at twiceprecision.jl:300\n",
+       "+(r1::StepRangeLen{T,S,S} where S, r2::StepRangeLen{T,S,S} where S) where {T, S} in Base at range.jl:905\n",
+       "+(r1::Union{LinSpace, OrdinalRange, StepRangeLen}, r2::Union{LinSpace, OrdinalRange, StepRangeLen}) in Base at range.jl:896\n",
+       "+(x::Base.TwicePrecision, y::Number) in Base at twiceprecision.jl:454\n",
+       "+(x::Number, y::Base.TwicePrecision) in Base at twiceprecision.jl:457\n",
+       "+(x::Base.TwicePrecision{T}, y::Base.TwicePrecision{T}) where T in Base at twiceprecision.jl:460\n",
+       "+(x::Base.TwicePrecision, y::Base.TwicePrecision) in Base at twiceprecision.jl:464\n",
+       "+(x::Ptr, y::Integer) in Base at pointer.jl:126\n",
+       "+(A::BitArray, B::BitArray) in Base at bitarray.jl:1176\n",
+       "+(A::SymTridiagonal, B::SymTridiagonal) in Base.LinAlg at linalg/tridiag.jl:128\n",
+       "+(A::Tridiagonal, B::Tridiagonal) in Base.LinAlg at linalg/tridiag.jl:624\n",
+       "+(A::UpperTriangular, B::UpperTriangular) in Base.LinAlg at linalg/triangular.jl:374\n",
+       "+(A::LowerTriangular, B::LowerTriangular) in Base.LinAlg at linalg/triangular.jl:375\n",
+       "+(A::UpperTriangular, B::Base.LinAlg.UnitUpperTriangular) in Base.LinAlg at linalg/triangular.jl:376\n",
+       "+(A::LowerTriangular, B::Base.LinAlg.UnitLowerTriangular) in Base.LinAlg at linalg/triangular.jl:377\n",
+       "+(A::Base.LinAlg.UnitUpperTriangular, B::UpperTriangular) in Base.LinAlg at linalg/triangular.jl:378\n",
+       "+(A::Base.LinAlg.UnitLowerTriangular, B::LowerTriangular) in Base.LinAlg at linalg/triangular.jl:379\n",
+       "+(A::Base.LinAlg.UnitUpperTriangular, B::Base.LinAlg.UnitUpperTriangular) in Base.LinAlg at linalg/triangular.jl:380\n",
+       "+(A::Base.LinAlg.UnitLowerTriangular, B::Base.LinAlg.UnitLowerTriangular) in Base.LinAlg at linalg/triangular.jl:381\n",
+       "+(A::Base.LinAlg.AbstractTriangular, B::Base.LinAlg.AbstractTriangular) in Base.LinAlg at linalg/triangular.jl:382\n",
+       "+(A::Symmetric, x::Bool) in Base.LinAlg at linalg/symmetric.jl:272\n",
+       "+(A::Symmetric, x::Number) in Base.LinAlg at linalg/symmetric.jl:274\n",
+       "+(A::Hermitian, x::Bool) in Base.LinAlg at linalg/symmetric.jl:272\n",
+       "+(A::Hermitian, x::Real) in Base.LinAlg at linalg/symmetric.jl:274\n",
+       "+(Da::Diagonal, Db::Diagonal) in Base.LinAlg at linalg/diagonal.jl:140\n",
+       "+(A::Bidiagonal, B::Bidiagonal) in Base.LinAlg at linalg/bidiag.jl:330\n",
+       "+(UL::UpperTriangular, J::UniformScaling) in Base.LinAlg at linalg/uniformscaling.jl:72\n",
+       "+(UL::Base.LinAlg.UnitUpperTriangular, J::UniformScaling) in Base.LinAlg at linalg/uniformscaling.jl:75\n",
+       "+(UL::LowerTriangular, J::UniformScaling) in Base.LinAlg at linalg/uniformscaling.jl:72\n",
+       "+(UL::Base.LinAlg.UnitLowerTriangular, J::UniformScaling) in Base.LinAlg at linalg/uniformscaling.jl:75\n",
+       "+(A::Array, B::SparseMatrixCSC) in Base.SparseArrays at sparse/sparsematrix.jl:1462\n",
+       "+(x::Union{Base.ReshapedArray{T,1,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{T,1}, SubArray{T,1,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where T, y::AbstractSparseArray{Tv,Ti,1} where Ti where Tv) in Base.SparseArrays at sparse/sparsevector.jl:1333\n",
+       "+(x::Union{Base.ReshapedArray{#s267,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{#s267,N}, SubArray{#s267,N,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where N where #s267<:Union{Base.Dates.CompoundPeriod, Base.Dates.Period}) in Base.Dates at dates/periods.jl:358\n",
+       "+(A::SparseMatrixCSC, J::UniformScaling) in Base.SparseArrays at sparse/sparsematrix.jl:3512\n",
+       "+(A::AbstractArray{TA,2}, J::UniformScaling{TJ}) where {TA, TJ} in Base.LinAlg at linalg/uniformscaling.jl:119\n",
+       "+(A::Diagonal, B::Bidiagonal) in Base.LinAlg at linalg/special.jl:113\n",
+       "+(A::Bidiagonal, B::Diagonal) in Base.LinAlg at linalg/special.jl:114\n",
+       "+(A::Diagonal, B::Tridiagonal) in Base.LinAlg at linalg/special.jl:113\n",
+       "+(A::Tridiagonal, B::Diagonal) in Base.LinAlg at linalg/special.jl:114\n",
+       "+(A::Diagonal, B::Array{T,2} where T) in Base.LinAlg at linalg/special.jl:113\n",
+       "+(A::Array{T,2} where T, B::Diagonal) in Base.LinAlg at linalg/special.jl:114\n",
+       "+(A::Bidiagonal, B::Tridiagonal) in Base.LinAlg at linalg/special.jl:113\n",
+       "+(A::Tridiagonal, B::Bidiagonal) in Base.LinAlg at linalg/special.jl:114\n",
+       "+(A::Bidiagonal, B::Array{T,2} where T) in Base.LinAlg at linalg/special.jl:113\n",
+       "+(A::Array{T,2} where T, B::Bidiagonal) in Base.LinAlg at linalg/special.jl:114\n",
+       "+(A::Tridiagonal, B::Array{T,2} where T) in Base.LinAlg at linalg/special.jl:113\n",
+       "+(A::Array{T,2} where T, B::Tridiagonal) in Base.LinAlg at linalg/special.jl:114\n",
+       "+(A::SymTridiagonal, B::Tridiagonal) in Base.LinAlg at linalg/special.jl:122\n",
+       "+(A::Tridiagonal, B::SymTridiagonal) in Base.LinAlg at linalg/special.jl:123\n",
+       "+(A::SymTridiagonal, B::Array{T,2} where T) in Base.LinAlg at linalg/special.jl:122\n",
+       "+(A::Array{T,2} where T, B::SymTridiagonal) in Base.LinAlg at linalg/special.jl:123\n",
+       "+(A::Diagonal, B::SymTridiagonal) in Base.LinAlg at linalg/special.jl:131\n",
+       "+(A::SymTridiagonal, B::Diagonal) in Base.LinAlg at linalg/special.jl:132\n",
+       "+(A::Bidiagonal, B::SymTridiagonal) in Base.LinAlg at linalg/special.jl:131\n",
+       "+(A::SymTridiagonal, B::Bidiagonal) in Base.LinAlg at linalg/special.jl:132\n",
+       "+(A::Diagonal, B::UpperTriangular) in Base.LinAlg at linalg/special.jl:143\n",
+       "+(A::UpperTriangular, B::Diagonal) in Base.LinAlg at linalg/special.jl:144\n",
+       "+(A::Diagonal, B::Base.LinAlg.UnitUpperTriangular) in Base.LinAlg at linalg/special.jl:143\n",
+       "+(A::Base.LinAlg.UnitUpperTriangular, B::Diagonal) in Base.LinAlg at linalg/special.jl:144\n",
+       "+(A::Diagonal, B::LowerTriangular) in Base.LinAlg at linalg/special.jl:143\n",
+       "+(A::LowerTriangular, B::Diagonal) in Base.LinAlg at linalg/special.jl:144\n",
+       "+(A::Diagonal, B::Base.LinAlg.UnitLowerTriangular) in Base.LinAlg at linalg/special.jl:143\n",
+       "+(A::Base.LinAlg.UnitLowerTriangular, B::Diagonal) in Base.LinAlg at linalg/special.jl:144\n",
+       "+(A::Base.LinAlg.AbstractTriangular, B::SymTridiagonal) in Base.LinAlg at linalg/special.jl:150\n",
+       "+(A::SymTridiagonal, B::Base.LinAlg.AbstractTriangular) in Base.LinAlg at linalg/special.jl:151\n",
+       "+(A::Base.LinAlg.AbstractTriangular, B::Tridiagonal) in Base.LinAlg at linalg/special.jl:150\n",
+       "+(A::Tridiagonal, B::Base.LinAlg.AbstractTriangular) in Base.LinAlg at linalg/special.jl:151\n",
+       "+(A::Base.LinAlg.AbstractTriangular, B::Bidiagonal) in Base.LinAlg at linalg/special.jl:150\n",
+       "+(A::Bidiagonal, B::Base.LinAlg.AbstractTriangular) in Base.LinAlg at linalg/special.jl:151\n",
+       "+(A::Base.LinAlg.AbstractTriangular, B::Array{T,2} where T) in Base.LinAlg at linalg/special.jl:150\n",
+       "+(A::Array{T,2} where T, B::Base.LinAlg.AbstractTriangular) in Base.LinAlg at linalg/special.jl:151\n",
+       "+(Y::Union{Base.ReshapedArray{#s266,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{#s266,N}, SubArray{#s266,N,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where N where #s266<:Union{Base.Dates.CompoundPeriod, Base.Dates.Period}, x::Union{Base.Dates.CompoundPeriod, Base.Dates.Period}) in Base.Dates at dates/periods.jl:363\n",
+       "+(X::Union{Base.ReshapedArray{#s265,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{#s265,N}, SubArray{#s265,N,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where N where #s265<:Union{Base.Dates.CompoundPeriod, Base.Dates.Period}, Y::Union{Base.ReshapedArray{#s264,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{#s264,N}, SubArray{#s264,N,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where N where #s264<:Union{Base.Dates.CompoundPeriod, Base.Dates.Period}) in Base.Dates at dates/periods.jl:364\n",
+       "+(x::Union{Base.ReshapedArray{#s267,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{#s267,N}, SubArray{#s267,N,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where N where #s267<:Union{Base.Dates.CompoundPeriod, Base.Dates.Period}, y::Base.Dates.TimeType) in Base.Dates at dates/arithmetic.jl:86\n",
+       "+(r::Range{#s267} where #s267<:Base.Dates.TimeType, x::Base.Dates.Period) in Base.Dates at dates/ranges.jl:47\n",
+       "+(A::SparseMatrixCSC, B::SparseMatrixCSC) in Base.SparseArrays at sparse/sparsematrix.jl:1458\n",
+       "+(A::SparseMatrixCSC, B::Array) in Base.SparseArrays at sparse/sparsematrix.jl:1461\n",
+       "+(x::AbstractSparseArray{Tv,Ti,1} where Ti where Tv, y::AbstractSparseArray{Tv,Ti,1} where Ti where Tv) in Base.SparseArrays at sparse/sparsevector.jl:1332\n",
+       "+(x::AbstractSparseArray{Tv,Ti,1} where Ti where Tv, y::Union{Base.ReshapedArray{T,1,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{T,1}, SubArray{T,1,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where T) in Base.SparseArrays at sparse/sparsevector.jl:1334\n",
+       "+(x::AbstractArray{#s45,N} where N where #s45<:Number) in Base at abstractarraymath.jl:93\n",
+       "+(A::AbstractArray, B::AbstractArray) in Base at arraymath.jl:37\n",
+       "+(A::Number, B::AbstractArray) in Base at arraymath.jl:44\n",
+       "+(A::AbstractArray, B::Number) in Base at arraymath.jl:47\n",
+       "+(index1::CartesianIndex{N}, index2::CartesianIndex{N}) where N in Base.IteratorsMD at multidimensional.jl:70\n",
+       "+(index::CartesianIndex{N}, i::Integer) where N in Base.IteratorsMD at multidimensional.jl:80\n",
+       "+(J1::UniformScaling, J2::UniformScaling) in Base.LinAlg at linalg/uniformscaling.jl:58\n",
+       "+(J::UniformScaling, B::BitArray{2}) in Base.LinAlg at linalg/uniformscaling.jl:60\n",
+       "+(J::UniformScaling, A::AbstractArray{T,2} where T) in Base.LinAlg at linalg/uniformscaling.jl:61\n",
+       "+(a::Base.Pkg.Resolve.VersionWeights.HierarchicalValue{T}, b::Base.Pkg.Resolve.VersionWeights.HierarchicalValue{T}) where T in Base.Pkg.Resolve.VersionWeights at pkg/resolve/versionweight.jl:23\n",
+       "+(x::P, y::P) where P<:Base.Dates.Period in Base.Dates at dates/periods.jl:70\n",
+       "+(x::Base.Dates.Period, y::Base.Dates.Period) in Base.Dates at dates/periods.jl:346\n",
+       "+(y::Base.Dates.Period, x::Base.Dates.CompoundPeriod) in Base.Dates at dates/periods.jl:348\n",
+       "+(x::Union{Base.Dates.CompoundPeriod, Base.Dates.Period}) in Base.Dates at dates/periods.jl:357\n",
+       "+(x::Union{Base.Dates.CompoundPeriod, Base.Dates.Period}, Y::Union{Base.ReshapedArray{#s267,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{#s267,N}, SubArray{#s267,N,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where N where #s267<:Union{Base.Dates.CompoundPeriod, Base.Dates.Period}) in Base.Dates at dates/periods.jl:362\n",
+       "+(x::Base.Dates.TimeType) in Base.Dates at dates/arithmetic.jl:8\n",
+       "+(a::Base.Dates.TimeType, b::Base.Dates.Period, c::Base.Dates.Period) in Base.Dates at dates/periods.jl:378\n",
+       "+(a::Base.Dates.TimeType, b::Base.Dates.Period, c::Base.Dates.Period, d::Base.Dates.Period...) in Base.Dates at dates/periods.jl:379\n",
+       "+(x::Base.Dates.TimeType, y::Base.Dates.CompoundPeriod) in Base.Dates at dates/periods.jl:382\n",
+       "+(x::Base.Dates.Instant) in Base.Dates at dates/arithmetic.jl:4\n",
+       "+(y::Base.Dates.Period, x::Base.Dates.TimeType) in Base.Dates at dates/arithmetic.jl:83\n",
+       "+(x::AbstractArray{#s267,N} where N where #s267<:Base.Dates.TimeType, y::Union{Base.Dates.CompoundPeriod, Base.Dates.Period}) in Base.Dates at dates/arithmetic.jl:85\n",
+       "+(x::Base.Dates.Period, r::Range{#s267} where #s267<:Base.Dates.TimeType) in Base.Dates at dates/ranges.jl:46\n",
+       "+(y::Union{Base.Dates.CompoundPeriod, Base.Dates.Period}, x::AbstractArray{#s267,N} where N where #s267<:Base.Dates.TimeType) in Base.Dates at dates/arithmetic.jl:87\n",
+       "+(y::Base.Dates.TimeType, x::Union{Base.ReshapedArray{#s267,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{#s267,N}, SubArray{#s267,N,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where N where #s267<:Union{Base.Dates.CompoundPeriod, Base.Dates.Period}) in Base.Dates at dates/arithmetic.jl:88\n",
+       "+(J::UniformScaling, x::Number) in Base at deprecated.jl:56\n",
+       "+(x::Number, J::UniformScaling) in Base at deprecated.jl:56\n",
+       "+(a, b, c, xs...) in Base at operators.jl:424"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "methods(+)   # careful, long output! Scroll down afterwards"
    ]
@@ -273,16 +581,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 79,
+   "metadata": {},
    "outputs": [],
    "source": [
     "immutable ModInt{N}\n",
     "    n :: Int64\n",
     "    \n",
-    "    ModInt(n) = new(mod(n,N))  # Inner constructor: make sure that 0 <= n < N\n",
+    "    ModInt{N}(n) where N = new(mod(n,N))  # Inner constructor: make sure that 0 <= n < N\n",
     "end"
    ]
   },
@@ -295,11 +601,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 80,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ModInt{7}(2)"
+      ]
+     },
+     "execution_count": 80,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "a = ModInt{7}(2)"
    ]
@@ -313,22 +628,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 82,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ModInt{7}"
+      ]
+     },
+     "execution_count": 82,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "typealias ModInt7 ModInt{7}"
+    "const ModInt7 = ModInt{7}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 83,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ModInt{7}(2)"
+      ]
+     },
+     "execution_count": 83,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "ModInt7(2)"
    ]
@@ -351,11 +684,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 84,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "+ (generic function with 183 methods)"
+      ]
+     },
+     "execution_count": 84,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import Base: +\n",
     "\n",
@@ -364,11 +706,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 85,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ModInt{7}(2)"
+      ]
+     },
+     "execution_count": 85,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "a = ModInt{7}(4)\n",
     "b = ModInt{7}(5)\n",
@@ -377,11 +728,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 86,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "+<i>{N}</i>(a::<b>ModInt{N}</b>, b::<b>ModInt{N}</b>) at In[84]:3"
+      ],
+      "text/plain": [
+       "+(a::ModInt{N}, b::ModInt{N}) where N in Main at In[84]:3"
+      ]
+     },
+     "execution_count": 86,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "@which a+b"
    ]
@@ -397,11 +760,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 87,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "LoadError",
+     "evalue": "\u001b[91mMethodError: no method matching +(::ModInt{7}, ::ModInt{5})\u001b[0m\nClosest candidates are:\n  +(::Any, ::Any, \u001b[91m::Any\u001b[39m, \u001b[91m::Any...\u001b[39m) at operators.jl:424\n  +(::ModInt{N}, \u001b[91m::ModInt{N}\u001b[39m) where N at In[84]:3\u001b[39m",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[91mMethodError: no method matching +(::ModInt{7}, ::ModInt{5})\u001b[0m\nClosest candidates are:\n  +(::Any, ::Any, \u001b[91m::Any\u001b[39m, \u001b[91m::Any...\u001b[39m) at operators.jl:424\n  +(::ModInt{N}, \u001b[91m::ModInt{N}\u001b[39m) where N at In[84]:3\u001b[39m",
+      "",
+      "Stacktrace:",
+      " [1] \u001b[1minclude_string\u001b[22m\u001b[22m\u001b[1m(\u001b[22m\u001b[22m::String, ::String\u001b[1m)\u001b[22m\u001b[22m at \u001b[1m./loading.jl:515\u001b[22m\u001b[22m"
+     ]
+    }
+   ],
    "source": [
     "ModInt{7}(2) + ModInt{5}(4)"
    ]
@@ -424,11 +797,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 88,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "* (generic function with 187 methods)"
+      ]
+     },
+     "execution_count": 88,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import Base: *\n",
     "\n",
@@ -437,11 +819,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 89,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ModInt{31}(17)"
+      ]
+     },
+     "execution_count": 89,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "4*ModInt{31}(12)"
    ]
@@ -455,11 +846,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 90,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "* (generic function with 187 methods)"
+      ]
+     },
+     "execution_count": 90,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "function *{N}(a::Int32, b::ModInt{N})\n",
     "    println(\"Hi. I see you're multiplying with an Int32. Good, because I have a better algorithm for this case!\")\n",
@@ -469,22 +869,47 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 91,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ModInt{7}(3)"
+      ]
+     },
+     "execution_count": 91,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "2 * ModInt{7}(5)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 92,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hi. I see you're multiplying with an Int32. Good, because I have a better algorithm for this case!\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "ModInt{7}(3)"
+      ]
+     },
+     "execution_count": 92,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "Int32(2) * ModInt{7}(5)"
    ]
@@ -516,22 +941,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 93,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "combine (generic function with 3 methods)"
+      ]
+     },
+     "execution_count": 93,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "combine(a, b::ModInt{7}) = \"method 1\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 94,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "combine (generic function with 3 methods)"
+      ]
+     },
+     "execution_count": 94,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "combine(a::ModInt{7}, b) = \"method 2\""
    ]
@@ -545,11 +988,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 95,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"method 3\""
+      ]
+     },
+     "execution_count": 95,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "combine(ModInt{7}(2), ModInt{7}(3))"
    ]
@@ -563,22 +1015,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 96,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "combine (generic function with 3 methods)"
+      ]
+     },
+     "execution_count": 96,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "combine(a::ModInt{7}, b::ModInt{7}) = \"method 3\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 97,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"method 3\""
+      ]
+     },
+     "execution_count": 97,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "combine(ModInt{7}(2), ModInt{7}(3))"
    ]
@@ -656,11 +1126,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 108,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "* (generic function with 187 methods)"
+      ]
+     },
+     "execution_count": 108,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import Base: size, rank, *, +\n",
     "\n",
@@ -687,11 +1166,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 109,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(10, 10)"
+      ]
+     },
+     "execution_count": 109,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "A = LowRankMatrix(rand(10,2), rand(10,2))\n",
     "size(A)"
@@ -699,22 +1187,50 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 110,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 110,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "rank(A)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 111,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "10-element Array{Float64,1}:\n",
+       " 2.06155 \n",
+       " 4.56947 \n",
+       " 2.04967 \n",
+       " 2.6158  \n",
+       " 0.821177\n",
+       " 2.28845 \n",
+       " 2.49972 \n",
+       " 3.03097 \n",
+       " 0.368683\n",
+       " 3.23455 "
+      ]
+     },
+     "execution_count": 111,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "A*rand(10)"
    ]
@@ -744,22 +1260,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 112,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "+ (generic function with 183 methods)"
+      ]
+     },
+     "execution_count": 112,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "+(mat1::LowRankMatrix, mat2::LowRankMatrix) = LowRankMatrix([mat1.a mat2.a], [mat2.b mat2.b])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 113,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4"
+      ]
+     },
+     "execution_count": 113,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "A = LowRankMatrix(rand(10,2), rand(10,2))\n",
     "B = LowRankMatrix(rand(10,2), rand(10,2))\n",
@@ -783,11 +1317,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 114,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "* (generic function with 187 methods)"
+      ]
+     },
+     "execution_count": 114,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "*(mat1::LowRankMatrix, mat2::AbstractMatrix) = LowRankMatrix(mat1.a, (mat1.b'*mat2)')"
    ]
@@ -801,44 +1344,86 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 115,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "* (generic function with 187 methods)"
+      ]
+     },
+     "execution_count": 115,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "*(mat1::LowRankMatrix, mat2::LowRankMatrix) = LowRankMatrix(mat1.a, mat1.b*mat2.a'*mat2.b)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 116,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "*(mat1::<b>LowRankMatrix</b>, mat2::<b>AbstractArray{T,2} where T</b>) at In[114]:1"
+      ],
+      "text/plain": [
+       "*(mat1::LowRankMatrix, mat2::AbstractArray{T,2} where T) in Main at In[114]:1"
+      ]
+     },
+     "execution_count": 116,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "@which A*rand(10,10)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 117,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "*(mat1::<b>LowRankMatrix</b>, mat2::<b>LowRankMatrix</b>) at In[115]:1"
+      ],
+      "text/plain": [
+       "*(mat1::LowRankMatrix, mat2::LowRankMatrix) in Main at In[115]:1"
+      ]
+     },
+     "execution_count": 117,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "@which A*B"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 118,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 118,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "rank(A*B)"
    ]
@@ -861,11 +1446,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 119,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4"
+      ]
+     },
+     "execution_count": 119,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "A = LowRankMatrix(rand(10,2), rand(10,2))\n",
     "rank(A+A)"
@@ -880,11 +1474,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 120,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "+ (generic function with 183 methods)"
+      ]
+     },
+     "execution_count": 120,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import Base: svd\n",
     "\n",
@@ -923,11 +1526,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 121,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 121,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "A = LowRankMatrix(rand(10,2), rand(10,2))\n",
     "rank(A+A)"
@@ -964,33 +1576,60 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 122,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "modint (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 122,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "modint(n, N) = ModInt{N}(n)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 123,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ModInt{7}(2)"
+      ]
+     },
+     "execution_count": 123,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "a = modint(2, 7)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 124,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ModInt{7}"
+      ]
+     },
+     "execution_count": 124,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "typeof(a)"
    ]
@@ -1011,11 +1650,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 125,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "CodeInfo(:(begin \n",
+       "        return $(Expr(:new, ModInt{Int64}, :((Base.convert)(Main.Int64, (Main.mod)(n, Int64)))))\n",
+       "    end))=>ModInt{Int64}"
+      ]
+     },
+     "execution_count": 125,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "@code_typed modint(Int64,Int64)"
    ]
@@ -1029,11 +1679,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 126,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "CodeInfo(:(begin \n",
+       "        $(Expr(:inbounds, false))\n",
+       "        # meta: location int.jl mod 170\n",
+       "        unless ($(Expr(:static_parameter, 1)) === -1)::Bool goto 6\n",
+       "        #temp# = 0\n",
+       "        goto 12\n",
+       "        6:  # line 171:\n",
+       "        # meta: location int.jl fld 191\n",
+       "        d = (Base.checked_sdiv_int)(n, $(Expr(:static_parameter, 1)))::Int64\n",
+       "        # meta: pop location\n",
+       "        #temp# = (Base.sub_int)(n, (Base.mul_int)((Base.sub_int)(d, (Base.and_int)((Base.zext_int)(Int64, (Base.and_int)((Base.slt_int)((Base.xor_int)(n, $(Expr(:static_parameter, 1)))::Int64, 0)::Bool, (Base.not_int)(((Base.mul_int)(d, $(Expr(:static_parameter, 1)))::Int64 === n)::Bool)::Bool)::Bool)::Int64, 1)::Int64)::Int64, $(Expr(:static_parameter, 1)))::Int64)::Int64\n",
+       "        12: \n",
+       "        # meta: pop location\n",
+       "        $(Expr(:inbounds, :pop))\n",
+       "        return $(Expr(:new, ModInt{7}, :(#temp#)))\n",
+       "    end))=>ModInt{7}"
+      ]
+     },
+     "execution_count": 126,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "@code_typed ModInt{7}(2)"
    ]
@@ -1074,10 +1748,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 127,
+   "metadata": {},
    "outputs": [],
    "source": [
     "type VerySlowType\n",
@@ -1094,11 +1766,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 128,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "sum (generic function with 17 methods)"
+      ]
+     },
+     "execution_count": 128,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import Base: sum\n",
     "\n",
@@ -1113,11 +1794,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 129,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Array{Float64,1}"
+      ]
+     },
+     "execution_count": 129,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "v = VerySlowType( rand(10000))\n",
     "typeof(v.some_array)"
@@ -1125,11 +1815,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 130,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0.002308 seconds (48.98 k allocations: 921.703 KiB)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "4977.432221886183"
+      ]
+     },
+     "execution_count": 130,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "sum(v)\n",
     "@time sum(v)"
@@ -1146,11 +1852,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 131,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "sum_some_array (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 131,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "sum2(v::VerySlowType) = sum_some_array(v.some_array)\n",
     "\n",
@@ -1165,11 +1880,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 132,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0.000018 seconds (5 allocations: 176 bytes)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "4986.03014367514"
+      ]
+     },
+     "execution_count": 132,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "v = VerySlowType( rand(10000))\n",
     "sum2(v)\n",
@@ -1216,7 +1947,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 133,
    "metadata": {
     "collapsed": true
    },
@@ -1239,22 +1970,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 134,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "16"
+      ]
+     },
+     "execution_count": 134,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "sizeof(ModInt2(5, 7))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 135,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "8"
+      ]
+     },
+     "execution_count": 135,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "sizeof(ModInt{7}(5))"
    ]
@@ -1270,11 +2019,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 136,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "+ (generic function with 183 methods)"
+      ]
+     },
+     "execution_count": 136,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "function +(a::ModInt2, b::ModInt2)\n",
     "    if a.N == b.N\n",
@@ -1296,23 +2054,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 138,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Array{Float64,2}"
+      ]
+     },
+     "execution_count": 138,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "a = Array(Float64, 10,10)\n",
+    "a = Array{Float64}(10,10)\n",
     "typeof(a)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 139,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(10, 10)"
+      ]
+     },
+     "execution_count": 139,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "size(a)"
    ]
@@ -1341,11 +2117,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 140,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dwt (generic function with 3 methods)"
+      ]
+     },
+     "execution_count": 140,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "function dwt(x, L, name)\n",
     "    if name == \"db2\"\n",
@@ -1367,13 +2152,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 142,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "abstract DiscreteWavelet\n",
+    "abstract type DiscreteWavelet\n",
+    "end\n",
     "\n",
     "immutable Daubechies{N} <: DiscreteWavelet\n",
     "end\n",
@@ -1384,11 +2168,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 143,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dwt (generic function with 3 methods)"
+      ]
+     },
+     "execution_count": 143,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "dwt{T <: DiscreteWavelet}(x, L, ::Type{T}) = \"Using a generic algorithm for some general wavelet\"\n",
     "\n",
@@ -1406,22 +2199,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 144,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"Using a generic algorithm for some general wavelet\""
+      ]
+     },
+     "execution_count": 144,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "dwt(rand(10), 4, SomeOtherWavelet)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 145,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"Computing a wavelet transform using Daubechies 2\""
+      ]
+     },
+     "execution_count": 145,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "dwt(rand(10), 4, Daubechies{2})"
    ]
@@ -1464,11 +2275,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 146,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "norm (generic function with 5 methods)"
+      ]
+     },
+     "execution_count": 146,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "function norm(x, p)\n",
     "    if p == 1\n",
@@ -1492,32 +2312,50 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 149,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "norm (generic function with 5 methods)"
+      ]
+     },
+     "execution_count": 149,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# general definition\n",
-    "norm{P}(x, ::Type{Val{P}}) = sum(abs(x).^P).^(1/P)\n",
+    "norm{P}(x, ::Type{Val{P}}) = sum(abs.(x).^P).^(1/P)\n",
     "\n",
     "# l0 norm: count number of non-zero entries\n",
     "norm(x, ::Type{Val{0}}) = countnz(x)\n",
     "\n",
     "# l1 norm: sum of absolute values\n",
-    "norm(x, ::Type{Val{1}}) = sum(abs(x))\n",
+    "norm(x, ::Type{Val{1}}) = sum(abs.(x))\n",
     "\n",
     "# l∞ norm: maximum of absolute value\n",
-    "norm(x, ::Type{Val{Inf}}) = maximum(abs(x))"
+    "norm(x, ::Type{Val{Inf}}) = maximum(abs.(x))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 150,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1.8435959875511116"
+      ]
+     },
+     "execution_count": 150,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "a = rand(10)\n",
     "norm(a, Val{2})"
@@ -1525,55 +2363,109 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 151,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4.936678661690902"
+      ]
+     },
+     "execution_count": 151,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "norm(a, Val{1})"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 152,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.9637592443771386"
+      ]
+     },
+     "execution_count": 152,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "norm(a, Val{Inf})"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 153,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "norm(x, ::<b>Type{Val{1}}</b>) at In[149]:8"
+      ],
+      "text/plain": [
+       "norm(x, ::Type{Val{1}}) in Main at In[149]:8"
+      ]
+     },
+     "execution_count": 153,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "@which norm(a, Val{1})"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 154,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "norm(x, ::<b>Type{Val{Inf}}</b>) at In[149]:11"
+      ],
+      "text/plain": [
+       "norm(x, ::Type{Val{Inf}}) in Main at In[149]:11"
+      ]
+     },
+     "execution_count": 154,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "@which norm(a, Val{Inf})"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 155,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "norm<i>{P}</i>(x, ::<b>Type{Val{P}}</b>) at In[149]:2"
+      ],
+      "text/plain": [
+       "norm(x, ::Type{Val{P}}) where P in Main at In[149]:2"
+      ]
+     },
+     "execution_count": 155,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "@which norm(a, Val{3})"
    ]
@@ -1615,17 +2507,17 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 0.4.0",
+   "display_name": "Julia 0.6.0",
    "language": "julia",
-   "name": "julia-0.4"
+   "name": "julia-0.6"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "0.4.0"
+   "version": "0.6.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/Julia-introduction-SIAM-SC.ipynb
+++ b/Julia-introduction-SIAM-SC.ipynb
@@ -1,0 +1,1319 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Introduction to Julia, \n",
+    "## SIAM Student Chapter KU Leuven\n",
+    "\n",
+    "This is a small tutorial to get to know some of the interesting functions of Julia, assuming the reader has prior general knowledge in programming languages (C++, Python, Matlab). \n",
+    "\n",
+    "This notebook is a collection of small code snippets illustrating different aspects of Julia.\n",
+    "\n",
+    "Most examples where taken from [the notebooks of Daan Huybrechs](https://github.com/daanhb/Julia-tutorial)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Basic syntax\n",
+    "#### 1. Variables\n",
+    "\n",
+    "You don't declare any types, but Julia will always deduce them (and if it can't, the type of your variable will be Any). Read all about variables [in the documentation](https://docs.julialang.org/en/stable/manual/variables/ \"Documentation\")."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a = 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Int64"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "typeof(a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Float64"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a = 8.0\n",
+    "typeof(a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3-element Array{Any,1}:\n",
+       " 2       \n",
+       " 5.0     \n",
+       "  \"hello\""
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "b = [2, 5.0, \"hello\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Variables are always references!\n",
+    "\n",
+    "This is important to note from the start: variables in Julia are just names associated with a value. This means we always have **reference semantics**! This is (very) different from Matlab.\n",
+    "\n",
+    "For example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4-element Array{Int64,1}:\n",
+       " 1\n",
+       " 2\n",
+       " 3\n",
+       " 4"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a = [1, 2, 3, 4]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4-element Array{Int64,1}:\n",
+       " 1\n",
+       " 5\n",
+       " 3\n",
+       " 4"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "b = a\n",
+    "b[2] = 5\n",
+    "b"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4-element Array{Int64,1}:\n",
+       " 1\n",
+       " 5\n",
+       " 3\n",
+       " 4"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can avoid reference semantics with an explicit copy:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4-element Array{Int64,1}:\n",
+       " 1\n",
+       " 7\n",
+       " 3\n",
+       " 4"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "c = copy(b)\n",
+    "c[2] = 7\n",
+    "c"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4-element Array{Int64,1}:\n",
+       " 1\n",
+       " 5\n",
+       " 3\n",
+       " 4"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "b"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since arrays are always passed by references, it becomes easy to make functions that modify their arguments - you can make **in-place algorithms**. Note for future reference the Julia convention of naming functions that modify one of their arguments in a particular way, namely ending in an exclamation point. For example, [see](http://docs.julialang.org/en/release-0.4/stdlib/collections/?highlight=push!#Base.push!) the `push!` function that changes a vector by adding an element to it.\n",
+    "\n",
+    "More importantly, reference semantics lets you avoid making unnecessary copies of data all over the place. Matlab avoids the copying using a copy-on-write mechanism. This is a valid choice to make, but it is still less efficient than just treating everything as a reference."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a = 4\n",
+    "b = a\n",
+    "b = 5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Modifying b did not modify a. Why? Because we did not actually modify b at all! The line b = 5 simply made b refer to a different integer, unrelated to what it was pointing at before. It is a new assignment, no different from the line a = 4 above.\n",
+    "\n",
+    "In any case, you can not change the value of an integer, because it is immutable. Arrays are mutable, in the sense that you can alter the third entry of an array. This does not make integers special in any way. Julia has mutable and immutable types, we will see that later.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 2. More on vectors\n",
+    "Vector can easily be generated using square brackets (see above), or using **list comprehensions**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "10-element Array{Int64,1}:\n",
+       "       1\n",
+       "       2\n",
+       "       6\n",
+       "      24\n",
+       "     120\n",
+       "     720\n",
+       "    5040\n",
+       "   40320\n",
+       "  362880\n",
+       " 3628800"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a = [factorial(i) for i=1:10]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4×4 Array{Float64,2}:\n",
+       " 0.5       0.333333  0.25      0.2     \n",
+       " 0.333333  0.25      0.2       0.166667\n",
+       " 0.25      0.2       0.166667  0.142857\n",
+       " 0.2       0.166667  0.142857  0.125   "
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "A = [1/(i+j) for i=1:4,j=1:4]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 3. Linear algebra\n",
+    "Most linear algebra operations you may know from Matlab also exist in Julia. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4×4 Array{Float64,2}:\n",
+       " -0.68089  -0.489555   -0.384651    -0.317628  \n",
+       "  0.0      -0.0415261  -0.0522176   -0.0539782 \n",
+       "  0.0       0.0        -0.00177233  -0.00310257\n",
+       "  0.0       0.0         0.0          4.71355e-5"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Q,R = qr(A)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "([2.13066e-5, 0.00182126, 0.0622678, 0.977556], [-0.0568608 -0.272282 0.662773 -0.695242; 0.407652 0.738785 -0.188579 -0.502448; -0.791397 0.0491555 -0.463099 -0.395998; 0.451971 -0.614526 -0.557413 -0.327674])"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "eig(A)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Control flow\n",
+    "The famous `for` and `if` statements work as expected."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Porsche\n",
+      "Audi\n",
+      "Tesla\n"
+     ]
+    }
+   ],
+   "source": [
+    "cars = [\"Porsche\", \"Audi\", \"Tesla\"]\n",
+    "for brand in cars\n",
+    "   println(brand) \n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following type of Matlab style ranges (for example 1:5) are possible."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hi from iteration 1\n",
+      "Hi from iteration 2\n",
+      "Hi from iteration 3\n",
+      "Hi from iteration 4\n",
+      "Hi from iteration 5\n"
+     ]
+    }
+   ],
+   "source": [
+    "for i in 1:5\n",
+    "   println(\"Hi from iteration $i\") \n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Statement is true.\n"
+     ]
+    }
+   ],
+   "source": [
+    "if 2<3\n",
+    "    println(\"Statement is true.\")\n",
+    "else\n",
+    "    println(\"Trump is a lie.\")\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Functions\n",
+    "Functions are a bit like in Matlab, except that you don't specify output variables. The last expression that is evaluated yields the return value (like it is in, say, Maple)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "fibonacci (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "function fibonacci(n)\n",
+    "    if (n == 1) || (n==0)\n",
+    "        1\n",
+    "    else\n",
+    "        fibonacci(n-1) + fibonacci(n-2)\n",
+    "    end\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "8"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fibonacci(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also explicitly write `return` if you like"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "function my_maximum(x,y)\n",
+    "    if x > y\n",
+    "        return x\n",
+    "    else\n",
+    "        return y\n",
+    "    end\n",
+    "end\n",
+    "my_maximum(2,3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, you can create anonymous functions.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(::#3) (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x -> cos(x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can pass around functions as arguments, including operators (which are really just functions)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "composite (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "composite(f, g, x) = f(g(x))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "composite(-, -, 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Type system\n",
+    "\n",
+    "We have already encounted a few types, including the numeric types Int64, Float64. Writing Julia revolves a lot around types. You will be making lots of them, and using them all the time. You can be generous with new types, they are not scarce. Sometimes code you write creates types implicitly just to get things done - in that case the type is essentially a use-once-throw-away commodity.\n",
+    "\n",
+    "#### 1. Composite type\n",
+    "You can compare a Julia type with a struct in C: it is an object that collects data. Member data are called fields. The data can be named and you define a type by listing the names of its fields."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "type MyType\n",
+    "    a\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MyType(5)"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "v = MyType(5)    # We instantiate an object of type MyType. There is a default constructor."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "v.a"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use untyped fields when you care about flexibility and simplicity more than performance. They do have unavoidable runtime overhead, so don't use untyped fields in a time-critical path of your code. In that case, do the following:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "type MyType2\n",
+    "    a :: Float64\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MyType2(2.0)"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "v = MyType2(2)      # Note the integer I've supplied is automatically converted to a float"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "LoadError",
+     "evalue": "\u001b[91mMethodError: Cannot `convert` an object of type String to an object of type Float64\nThis may have arisen from a call to the constructor Float64(...),\nsince type constructors fall back to convert methods.\u001b[39m",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[91mMethodError: Cannot `convert` an object of type String to an object of type Float64\nThis may have arisen from a call to the constructor Float64(...),\nsince type constructors fall back to convert methods.\u001b[39m",
+      "",
+      "Stacktrace:",
+      " [1] \u001b[1minclude_string\u001b[22m\u001b[22m\u001b[1m(\u001b[22m\u001b[22m::String, ::String\u001b[1m)\u001b[22m\u001b[22m at \u001b[1m./loading.jl:515\u001b[22m\u001b[22m"
+     ]
+    }
+   ],
+   "source": [
+    "v.a = \"I'm an evil string.\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There is a difference in runtime. Let's read the field's value of the declared type many times."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "add_field_values_many_times (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "function add_field_values_many_times(m)\n",
+    "    z = 0.0\n",
+    "    for i = 1:10000\n",
+    "        z = z + m.a\n",
+    "    end\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0.000199 seconds (10.09 k allocations: 162.717 KiB)\n"
+     ]
+    }
+   ],
+   "source": [
+    "add_field_values_many_times(MyType(10.0))\n",
+    "@time add_field_values_many_times(MyType(10.0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0.000009 seconds (5 allocations: 176 bytes)\n"
+     ]
+    }
+   ],
+   "source": [
+    "add_field_values_many_times(MyType2(10.0))\n",
+    "@time add_field_values_many_times(MyType2(10.0))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There is much more too say about it (immutable types,etc ), be sure to check the documentation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 2. Parametric types"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "immutable Point{T}\n",
+    "    x :: T\n",
+    "    y :: T\n",
+    "    z :: T\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Point{Float64}(0.1, 0.2, 0.4)"
+      ]
+     },
+     "execution_count": 52,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "p = Point(0.1, 0.2, 0.4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.1"
+      ]
+     },
+     "execution_count": 53,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "p.x"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Why would I define a point this way? I want to specify the types of x, y and z, so that Julia knows them and produces optimized code. But I don't want to specify that they are Float64. What if my user wants to use BigFloat's? Or integers? Or something else entirely I do not know about, some user-defined numeric type? In this case, parameters are the answer.\n",
+    "\n",
+    "Type parameters in Julia look a lot like C++ template parameters. A major difference is that C++ templates are mostly syntactic sugar at compile-time. You could achieve what they do, if you have the patience, by using copy-paste of text over and over again. In Julia, parametric types and methods are a major part of the language in all stages of execution.\n",
+    "\n",
+    "I am skipping over many things here, like default and user-supplied constructors. There are inner and outer constructors. They can be painful at times. Please read the manual on [constructors](http://docs.julialang.org/en/stable/manual/constructors/), especially [parametric constructors](http://docs.julialang.org/en/stable/manual/constructors/#parametric-constructors), and don't complain to me.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### 3. Abstract types\n",
+    "Sure enough, types can inherit from other types. You can create an abstract type and then inherit from it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "abstract type AbstractPoint \n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "immutable Point2d <: AbstractPoint\n",
+    "    x :: Float64\n",
+    "    y :: Float64\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "immutable Point3d <: AbstractPoint\n",
+    "    x :: Float64\n",
+    "    y :: Float64\n",
+    "    z :: Float64\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Point2d"
+      ]
+     },
+     "execution_count": 58,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "p2 = Point2d(0.1, 2.0)\n",
+    "typeof(p2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AbstractPoint"
+      ]
+     },
+     "execution_count": 62,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "supertype(Point3d)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Any type that is not abstract is a concrete type. You can not inherit from concrete types. For example, we could not create a subset of Point2d's, say a subset that has unit norm, as follows:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "LoadError",
+     "evalue": "\u001b[91minvalid subtyping in definition of Point2d_with_unit_norm\u001b[39m",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[91minvalid subtyping in definition of Point2d_with_unit_norm\u001b[39m",
+      "",
+      "Stacktrace:",
+      " [1] \u001b[1minclude_string\u001b[22m\u001b[22m\u001b[1m(\u001b[22m\u001b[22m::String, ::String\u001b[1m)\u001b[22m\u001b[22m at \u001b[1m./loading.jl:515\u001b[22m\u001b[22m"
+     ]
+    }
+   ],
+   "source": [
+    "type Point2d_with_unit_norm <: Point2d\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Multiple dispatch\n",
+    "But what are types? All variables have a type. It is compiler metadata that describes what your variable stands for. Julia types compare a little bit to classes in an object-oriented language, but one should not stretch the comparison too much. Types do support inheritance. However, you are well advised to resist that initial urge to create a fancy hierarchical tree of types like you would in OOP: there is no need for that. The best reason to use types in Julia (and some would say the only reason) is to use multiple dispatch, and that is the topic of the next chapter.\n",
+    "\n",
+    "Without multiple dispatch it is hard to convey the richness of the type system. Still, we have a quite a few things to discover already. \n",
+    "\n",
+    "#### Methods are algorithms are methods: Julia selects the best available algorithm for the problem at hand\n",
+    "Function overloading is possible in many typed languagues, but in Julia it is really pervasive. You add methods to existing functions all the time. Popular ones are the basic operators, like +:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "180 methods for generic function <b>+</b>:<ul><li> +(x::<b>Bool</b>, z::<b>Complex{Bool}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/complex.jl#L232\" target=\"_blank\">complex.jl:232</a></li> <li> +(x::<b>Bool</b>, y::<b>Bool</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/bool.jl#L89\" target=\"_blank\">bool.jl:89</a></li> <li> +(x::<b>Bool</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/bool.jl#L86\" target=\"_blank\">bool.jl:86</a></li> <li> +<i>{T<:AbstractFloat}</i>(x::<b>Bool</b>, y::<b>T</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/bool.jl#L96\" target=\"_blank\">bool.jl:96</a></li> <li> +(x::<b>Bool</b>, z::<b>Complex</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/complex.jl#L239\" target=\"_blank\">complex.jl:239</a></li> <li> +(a::<b>Float16</b>, b::<b>Float16</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/float.jl#L372\" target=\"_blank\">float.jl:372</a></li> <li> +(x::<b>Float32</b>, y::<b>Float32</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/float.jl#L374\" target=\"_blank\">float.jl:374</a></li> <li> +(x::<b>Float64</b>, y::<b>Float64</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/float.jl#L375\" target=\"_blank\">float.jl:375</a></li> <li> +(z::<b>Complex{Bool}</b>, x::<b>Bool</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/complex.jl#L233\" target=\"_blank\">complex.jl:233</a></li> <li> +(z::<b>Complex{Bool}</b>, x::<b>Real</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/complex.jl#L247\" target=\"_blank\">complex.jl:247</a></li> <li> +(x::<b>Char</b>, y::<b>Integer</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/char.jl#L40\" target=\"_blank\">char.jl:40</a></li> <li> +(c::<b>BigInt</b>, x::<b>BigFloat</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/mpfr.jl#L312\" target=\"_blank\">mpfr.jl:312</a></li> <li> +(a::<b>BigInt</b>, b::<b>BigInt</b>, c::<b>BigInt</b>, d::<b>BigInt</b>, e::<b>BigInt</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/gmp.jl#L334\" target=\"_blank\">gmp.jl:334</a></li> <li> +(a::<b>BigInt</b>, b::<b>BigInt</b>, c::<b>BigInt</b>, d::<b>BigInt</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/gmp.jl#L327\" target=\"_blank\">gmp.jl:327</a></li> <li> +(a::<b>BigInt</b>, b::<b>BigInt</b>, c::<b>BigInt</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/gmp.jl#L321\" target=\"_blank\">gmp.jl:321</a></li> <li> +(x::<b>BigInt</b>, y::<b>BigInt</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/gmp.jl#L289\" target=\"_blank\">gmp.jl:289</a></li> <li> +(x::<b>BigInt</b>, c::<b>Union{UInt16, UInt32, UInt64, UInt8}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/gmp.jl#L346\" target=\"_blank\">gmp.jl:346</a></li> <li> +(x::<b>BigInt</b>, c::<b>Union{Int16, Int32, Int64, Int8}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/gmp.jl#L362\" target=\"_blank\">gmp.jl:362</a></li> <li> +(a::<b>BigFloat</b>, b::<b>BigFloat</b>, c::<b>BigFloat</b>, d::<b>BigFloat</b>, e::<b>BigFloat</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/mpfr.jl#L460\" target=\"_blank\">mpfr.jl:460</a></li> <li> +(a::<b>BigFloat</b>, b::<b>BigFloat</b>, c::<b>BigFloat</b>, d::<b>BigFloat</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/mpfr.jl#L453\" target=\"_blank\">mpfr.jl:453</a></li> <li> +(a::<b>BigFloat</b>, b::<b>BigFloat</b>, c::<b>BigFloat</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/mpfr.jl#L447\" target=\"_blank\">mpfr.jl:447</a></li> <li> +(x::<b>BigFloat</b>, c::<b>BigInt</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/mpfr.jl#L308\" target=\"_blank\">mpfr.jl:308</a></li> <li> +(x::<b>BigFloat</b>, y::<b>BigFloat</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/mpfr.jl#L277\" target=\"_blank\">mpfr.jl:277</a></li> <li> +(x::<b>BigFloat</b>, c::<b>Union{UInt16, UInt32, UInt64, UInt8}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/mpfr.jl#L284\" target=\"_blank\">mpfr.jl:284</a></li> <li> +(x::<b>BigFloat</b>, c::<b>Union{Int16, Int32, Int64, Int8}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/mpfr.jl#L292\" target=\"_blank\">mpfr.jl:292</a></li> <li> +(x::<b>BigFloat</b>, c::<b>Union{Float16, Float32, Float64}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/mpfr.jl#L300\" target=\"_blank\">mpfr.jl:300</a></li> <li> +(B::<b>BitArray{2}</b>, J::<b>UniformScaling</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/uniformscaling.jl#L59\" target=\"_blank\">linalg/uniformscaling.jl:59</a></li> <li> +(a::<b>Base.Pkg.Resolve.VersionWeights.VWPreBuildItem</b>, b::<b>Base.Pkg.Resolve.VersionWeights.VWPreBuildItem</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/pkg/resolve/versionweight.jl#L87\" target=\"_blank\">pkg/resolve/versionweight.jl:87</a></li> <li> +(a::<b>Base.Pkg.Resolve.VersionWeights.VWPreBuild</b>, b::<b>Base.Pkg.Resolve.VersionWeights.VWPreBuild</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/pkg/resolve/versionweight.jl#L135\" target=\"_blank\">pkg/resolve/versionweight.jl:135</a></li> <li> +(a::<b>Base.Pkg.Resolve.VersionWeights.VersionWeight</b>, b::<b>Base.Pkg.Resolve.VersionWeights.VersionWeight</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/pkg/resolve/versionweight.jl#L197\" target=\"_blank\">pkg/resolve/versionweight.jl:197</a></li> <li> +(a::<b>Base.Pkg.Resolve.MaxSum.FieldValues.FieldValue</b>, b::<b>Base.Pkg.Resolve.MaxSum.FieldValues.FieldValue</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/pkg/resolve/fieldvalue.jl#L44\" target=\"_blank\">pkg/resolve/fieldvalue.jl:44</a></li> <li> +(x::<b>Base.Dates.CompoundPeriod</b>, y::<b>Base.Dates.CompoundPeriod</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/periods.jl#L349\" target=\"_blank\">dates/periods.jl:349</a></li> <li> +(x::<b>Base.Dates.CompoundPeriod</b>, y::<b>Base.Dates.Period</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/periods.jl#L347\" target=\"_blank\">dates/periods.jl:347</a></li> <li> +(x::<b>Base.Dates.CompoundPeriod</b>, y::<b>Base.Dates.TimeType</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/periods.jl#L387\" target=\"_blank\">dates/periods.jl:387</a></li> <li> +(x::<b>Date</b>, y::<b>Base.Dates.Day</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L77\" target=\"_blank\">dates/arithmetic.jl:77</a></li> <li> +(x::<b>Date</b>, y::<b>Base.Dates.Week</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L75\" target=\"_blank\">dates/arithmetic.jl:75</a></li> <li> +(dt::<b>Date</b>, z::<b>Base.Dates.Month</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L58\" target=\"_blank\">dates/arithmetic.jl:58</a></li> <li> +(dt::<b>Date</b>, y::<b>Base.Dates.Year</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L32\" target=\"_blank\">dates/arithmetic.jl:32</a></li> <li> +(dt::<b>Date</b>, t::<b>Base.Dates.Time</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L20\" target=\"_blank\">dates/arithmetic.jl:20</a></li> <li> +(t::<b>Base.Dates.Time</b>, dt::<b>Date</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L24\" target=\"_blank\">dates/arithmetic.jl:24</a></li> <li> +(x::<b>Base.Dates.Time</b>, y::<b>Base.Dates.TimePeriod</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L81\" target=\"_blank\">dates/arithmetic.jl:81</a></li> <li> +(dt::<b>DateTime</b>, z::<b>Base.Dates.Month</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L52\" target=\"_blank\">dates/arithmetic.jl:52</a></li> <li> +(dt::<b>DateTime</b>, y::<b>Base.Dates.Year</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L28\" target=\"_blank\">dates/arithmetic.jl:28</a></li> <li> +(x::<b>DateTime</b>, y::<b>Base.Dates.Period</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L79\" target=\"_blank\">dates/arithmetic.jl:79</a></li> <li> +(y::<b>AbstractFloat</b>, x::<b>Bool</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/bool.jl#L98\" target=\"_blank\">bool.jl:98</a></li> <li> +<i>{T<:Union{Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64, UInt8}}</i>(x::<b>T</b>, y::<b>T</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/int.jl#L32\" target=\"_blank\">int.jl:32</a></li> <li> +(x::<b>Integer</b>, y::<b>Ptr</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/pointer.jl#L128\" target=\"_blank\">pointer.jl:128</a></li> <li> +(z::<b>Complex</b>, w::<b>Complex</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/complex.jl#L221\" target=\"_blank\">complex.jl:221</a></li> <li> +(z::<b>Complex</b>, x::<b>Bool</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/complex.jl#L240\" target=\"_blank\">complex.jl:240</a></li> <li> +(x::<b>Real</b>, z::<b>Complex{Bool}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/complex.jl#L246\" target=\"_blank\">complex.jl:246</a></li> <li> +(x::<b>Real</b>, z::<b>Complex</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/complex.jl#L258\" target=\"_blank\">complex.jl:258</a></li> <li> +(z::<b>Complex</b>, x::<b>Real</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/complex.jl#L259\" target=\"_blank\">complex.jl:259</a></li> <li> +(x::<b>Rational</b>, y::<b>Rational</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/rational.jl#L245\" target=\"_blank\">rational.jl:245</a></li> <li> +(x::<b>Integer</b>, y::<b>Char</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/char.jl#L41\" target=\"_blank\">char.jl:41</a></li> <li> +(i::<b>Integer</b>, index::<b>CartesianIndex</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/multidimensional.jl#L79\" target=\"_blank\">multidimensional.jl:79</a></li> <li> +(c::<b>Union{UInt16, UInt32, UInt64, UInt8}</b>, x::<b>BigInt</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/gmp.jl#L350\" target=\"_blank\">gmp.jl:350</a></li> <li> +(c::<b>Union{Int16, Int32, Int64, Int8}</b>, x::<b>BigInt</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/gmp.jl#L363\" target=\"_blank\">gmp.jl:363</a></li> <li> +(c::<b>Union{UInt16, UInt32, UInt64, UInt8}</b>, x::<b>BigFloat</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/mpfr.jl#L288\" target=\"_blank\">mpfr.jl:288</a></li> <li> +(c::<b>Union{Int16, Int32, Int64, Int8}</b>, x::<b>BigFloat</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/mpfr.jl#L296\" target=\"_blank\">mpfr.jl:296</a></li> <li> +(c::<b>Union{Float16, Float32, Float64}</b>, x::<b>BigFloat</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/mpfr.jl#L304\" target=\"_blank\">mpfr.jl:304</a></li> <li> +(x::<b>Irrational</b>, y::<b>Irrational</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/irrationals.jl#L109\" target=\"_blank\">irrationals.jl:109</a></li> <li> +(x::<b>Real</b>, r::<b>Base.Use_StepRangeLen_Instead</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/deprecated.jl#L1223\" target=\"_blank\">deprecated.jl:1223</a></li> <li> +(x::<b>Number</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/operators.jl#L399\" target=\"_blank\">operators.jl:399</a></li> <li> +<i>{T<:Number}</i>(x::<b>T</b>, y::<b>T</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/promotion.jl#L335\" target=\"_blank\">promotion.jl:335</a></li> <li> +(x::<b>Number</b>, y::<b>Number</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/promotion.jl#L249\" target=\"_blank\">promotion.jl:249</a></li> <li> +(x::<b>Real</b>, r::<b>AbstractUnitRange</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/range.jl#L721\" target=\"_blank\">range.jl:721</a></li> <li> +(x::<b>Number</b>, r::<b>AbstractUnitRange</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/range.jl#L723\" target=\"_blank\">range.jl:723</a></li> <li> +(x::<b>Number</b>, r::<b>StepRangeLen</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/range.jl#L726\" target=\"_blank\">range.jl:726</a></li> <li> +(x::<b>Number</b>, r::<b>LinSpace</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/range.jl#L730\" target=\"_blank\">range.jl:730</a></li> <li> +(x::<b>Number</b>, r::<b>Range</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/range.jl#L724\" target=\"_blank\">range.jl:724</a></li> <li> +(r::<b>Range</b>, x::<b>Number</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/range.jl#L732\" target=\"_blank\">range.jl:732</a></li> <li> +(r1::<b>OrdinalRange</b>, r2::<b>OrdinalRange</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/range.jl#L882\" target=\"_blank\">range.jl:882</a></li> <li> +<i>{T}</i>(r1::<b>LinSpace{T}</b>, r2::<b>LinSpace{T}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/range.jl#L889\" target=\"_blank\">range.jl:889</a></li> <li> +<i>{R<:Base.TwicePrecision, T}</i>(r1::<b>StepRangeLen{T,R,S} where S</b>, r2::<b>StepRangeLen{T,R,S} where S</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/twiceprecision.jl#L300\" target=\"_blank\">twiceprecision.jl:300</a></li> <li> +<i>{T, S}</i>(r1::<b>StepRangeLen{T,S,S} where S</b>, r2::<b>StepRangeLen{T,S,S} where S</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/range.jl#L905\" target=\"_blank\">range.jl:905</a></li> <li> +(r1::<b>Union{LinSpace, OrdinalRange, StepRangeLen}</b>, r2::<b>Union{LinSpace, OrdinalRange, StepRangeLen}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/range.jl#L896\" target=\"_blank\">range.jl:896</a></li> <li> +(x::<b>Base.TwicePrecision</b>, y::<b>Number</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/twiceprecision.jl#L454\" target=\"_blank\">twiceprecision.jl:454</a></li> <li> +(x::<b>Number</b>, y::<b>Base.TwicePrecision</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/twiceprecision.jl#L457\" target=\"_blank\">twiceprecision.jl:457</a></li> <li> +<i>{T}</i>(x::<b>Base.TwicePrecision{T}</b>, y::<b>Base.TwicePrecision{T}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/twiceprecision.jl#L460\" target=\"_blank\">twiceprecision.jl:460</a></li> <li> +(x::<b>Base.TwicePrecision</b>, y::<b>Base.TwicePrecision</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/twiceprecision.jl#L464\" target=\"_blank\">twiceprecision.jl:464</a></li> <li> +(x::<b>Ptr</b>, y::<b>Integer</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/pointer.jl#L126\" target=\"_blank\">pointer.jl:126</a></li> <li> +(A::<b>BitArray</b>, B::<b>BitArray</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/bitarray.jl#L1176\" target=\"_blank\">bitarray.jl:1176</a></li> <li> +(A::<b>SymTridiagonal</b>, B::<b>SymTridiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/tridiag.jl#L128\" target=\"_blank\">linalg/tridiag.jl:128</a></li> <li> +(A::<b>Tridiagonal</b>, B::<b>Tridiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/tridiag.jl#L624\" target=\"_blank\">linalg/tridiag.jl:624</a></li> <li> +(A::<b>UpperTriangular</b>, B::<b>UpperTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/triangular.jl#L374\" target=\"_blank\">linalg/triangular.jl:374</a></li> <li> +(A::<b>LowerTriangular</b>, B::<b>LowerTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/triangular.jl#L375\" target=\"_blank\">linalg/triangular.jl:375</a></li> <li> +(A::<b>UpperTriangular</b>, B::<b>Base.LinAlg.UnitUpperTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/triangular.jl#L376\" target=\"_blank\">linalg/triangular.jl:376</a></li> <li> +(A::<b>LowerTriangular</b>, B::<b>Base.LinAlg.UnitLowerTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/triangular.jl#L377\" target=\"_blank\">linalg/triangular.jl:377</a></li> <li> +(A::<b>Base.LinAlg.UnitUpperTriangular</b>, B::<b>UpperTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/triangular.jl#L378\" target=\"_blank\">linalg/triangular.jl:378</a></li> <li> +(A::<b>Base.LinAlg.UnitLowerTriangular</b>, B::<b>LowerTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/triangular.jl#L379\" target=\"_blank\">linalg/triangular.jl:379</a></li> <li> +(A::<b>Base.LinAlg.UnitUpperTriangular</b>, B::<b>Base.LinAlg.UnitUpperTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/triangular.jl#L380\" target=\"_blank\">linalg/triangular.jl:380</a></li> <li> +(A::<b>Base.LinAlg.UnitLowerTriangular</b>, B::<b>Base.LinAlg.UnitLowerTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/triangular.jl#L381\" target=\"_blank\">linalg/triangular.jl:381</a></li> <li> +(A::<b>Base.LinAlg.AbstractTriangular</b>, B::<b>Base.LinAlg.AbstractTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/triangular.jl#L382\" target=\"_blank\">linalg/triangular.jl:382</a></li> <li> +(A::<b>Symmetric</b>, x::<b>Bool</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/symmetric.jl#L272\" target=\"_blank\">linalg/symmetric.jl:272</a></li> <li> +(A::<b>Symmetric</b>, x::<b>Number</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/symmetric.jl#L274\" target=\"_blank\">linalg/symmetric.jl:274</a></li> <li> +(A::<b>Hermitian</b>, x::<b>Bool</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/symmetric.jl#L272\" target=\"_blank\">linalg/symmetric.jl:272</a></li> <li> +(A::<b>Hermitian</b>, x::<b>Real</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/symmetric.jl#L274\" target=\"_blank\">linalg/symmetric.jl:274</a></li> <li> +(Da::<b>Diagonal</b>, Db::<b>Diagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/diagonal.jl#L140\" target=\"_blank\">linalg/diagonal.jl:140</a></li> <li> +(A::<b>Bidiagonal</b>, B::<b>Bidiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/bidiag.jl#L330\" target=\"_blank\">linalg/bidiag.jl:330</a></li> <li> +(UL::<b>UpperTriangular</b>, J::<b>UniformScaling</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/uniformscaling.jl#L72\" target=\"_blank\">linalg/uniformscaling.jl:72</a></li> <li> +(UL::<b>Base.LinAlg.UnitUpperTriangular</b>, J::<b>UniformScaling</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/uniformscaling.jl#L75\" target=\"_blank\">linalg/uniformscaling.jl:75</a></li> <li> +(UL::<b>LowerTriangular</b>, J::<b>UniformScaling</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/uniformscaling.jl#L72\" target=\"_blank\">linalg/uniformscaling.jl:72</a></li> <li> +(UL::<b>Base.LinAlg.UnitLowerTriangular</b>, J::<b>UniformScaling</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/uniformscaling.jl#L75\" target=\"_blank\">linalg/uniformscaling.jl:75</a></li> <li> +(A::<b>Array</b>, B::<b>SparseMatrixCSC</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/sparse/sparsematrix.jl#L1462\" target=\"_blank\">sparse/sparsematrix.jl:1462</a></li> <li> +(x::<b>Union{Base.ReshapedArray{T,1,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{T,1}, SubArray{T,1,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where T</b>, y::<b>AbstractSparseArray{Tv,Ti,1} where Ti where Tv</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/sparse/sparsevector.jl#L1333\" target=\"_blank\">sparse/sparsevector.jl:1333</a></li> <li> +(x::<b>Union{Base.ReshapedArray{#s267,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{#s267,N}, SubArray{#s267,N,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where N where #s267<:Union{Base.Dates.CompoundPeriod, Base.Dates.Period}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/periods.jl#L358\" target=\"_blank\">dates/periods.jl:358</a></li> <li> +(A::<b>SparseMatrixCSC</b>, J::<b>UniformScaling</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/sparse/sparsematrix.jl#L3512\" target=\"_blank\">sparse/sparsematrix.jl:3512</a></li> <li> +<i>{TA, TJ}</i>(A::<b>AbstractArray{TA,2}</b>, J::<b>UniformScaling{TJ}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/uniformscaling.jl#L119\" target=\"_blank\">linalg/uniformscaling.jl:119</a></li> <li> +(A::<b>Diagonal</b>, B::<b>Bidiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L113\" target=\"_blank\">linalg/special.jl:113</a></li> <li> +(A::<b>Bidiagonal</b>, B::<b>Diagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L114\" target=\"_blank\">linalg/special.jl:114</a></li> <li> +(A::<b>Diagonal</b>, B::<b>Tridiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L113\" target=\"_blank\">linalg/special.jl:113</a></li> <li> +(A::<b>Tridiagonal</b>, B::<b>Diagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L114\" target=\"_blank\">linalg/special.jl:114</a></li> <li> +(A::<b>Diagonal</b>, B::<b>Array{T,2} where T</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L113\" target=\"_blank\">linalg/special.jl:113</a></li> <li> +(A::<b>Array{T,2} where T</b>, B::<b>Diagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L114\" target=\"_blank\">linalg/special.jl:114</a></li> <li> +(A::<b>Bidiagonal</b>, B::<b>Tridiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L113\" target=\"_blank\">linalg/special.jl:113</a></li> <li> +(A::<b>Tridiagonal</b>, B::<b>Bidiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L114\" target=\"_blank\">linalg/special.jl:114</a></li> <li> +(A::<b>Bidiagonal</b>, B::<b>Array{T,2} where T</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L113\" target=\"_blank\">linalg/special.jl:113</a></li> <li> +(A::<b>Array{T,2} where T</b>, B::<b>Bidiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L114\" target=\"_blank\">linalg/special.jl:114</a></li> <li> +(A::<b>Tridiagonal</b>, B::<b>Array{T,2} where T</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L113\" target=\"_blank\">linalg/special.jl:113</a></li> <li> +(A::<b>Array{T,2} where T</b>, B::<b>Tridiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L114\" target=\"_blank\">linalg/special.jl:114</a></li> <li> +(A::<b>SymTridiagonal</b>, B::<b>Tridiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L122\" target=\"_blank\">linalg/special.jl:122</a></li> <li> +(A::<b>Tridiagonal</b>, B::<b>SymTridiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L123\" target=\"_blank\">linalg/special.jl:123</a></li> <li> +(A::<b>SymTridiagonal</b>, B::<b>Array{T,2} where T</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L122\" target=\"_blank\">linalg/special.jl:122</a></li> <li> +(A::<b>Array{T,2} where T</b>, B::<b>SymTridiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L123\" target=\"_blank\">linalg/special.jl:123</a></li> <li> +(A::<b>Diagonal</b>, B::<b>SymTridiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L131\" target=\"_blank\">linalg/special.jl:131</a></li> <li> +(A::<b>SymTridiagonal</b>, B::<b>Diagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L132\" target=\"_blank\">linalg/special.jl:132</a></li> <li> +(A::<b>Bidiagonal</b>, B::<b>SymTridiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L131\" target=\"_blank\">linalg/special.jl:131</a></li> <li> +(A::<b>SymTridiagonal</b>, B::<b>Bidiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L132\" target=\"_blank\">linalg/special.jl:132</a></li> <li> +(A::<b>Diagonal</b>, B::<b>UpperTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L143\" target=\"_blank\">linalg/special.jl:143</a></li> <li> +(A::<b>UpperTriangular</b>, B::<b>Diagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L144\" target=\"_blank\">linalg/special.jl:144</a></li> <li> +(A::<b>Diagonal</b>, B::<b>Base.LinAlg.UnitUpperTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L143\" target=\"_blank\">linalg/special.jl:143</a></li> <li> +(A::<b>Base.LinAlg.UnitUpperTriangular</b>, B::<b>Diagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L144\" target=\"_blank\">linalg/special.jl:144</a></li> <li> +(A::<b>Diagonal</b>, B::<b>LowerTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L143\" target=\"_blank\">linalg/special.jl:143</a></li> <li> +(A::<b>LowerTriangular</b>, B::<b>Diagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L144\" target=\"_blank\">linalg/special.jl:144</a></li> <li> +(A::<b>Diagonal</b>, B::<b>Base.LinAlg.UnitLowerTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L143\" target=\"_blank\">linalg/special.jl:143</a></li> <li> +(A::<b>Base.LinAlg.UnitLowerTriangular</b>, B::<b>Diagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L144\" target=\"_blank\">linalg/special.jl:144</a></li> <li> +(A::<b>Base.LinAlg.AbstractTriangular</b>, B::<b>SymTridiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L150\" target=\"_blank\">linalg/special.jl:150</a></li> <li> +(A::<b>SymTridiagonal</b>, B::<b>Base.LinAlg.AbstractTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L151\" target=\"_blank\">linalg/special.jl:151</a></li> <li> +(A::<b>Base.LinAlg.AbstractTriangular</b>, B::<b>Tridiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L150\" target=\"_blank\">linalg/special.jl:150</a></li> <li> +(A::<b>Tridiagonal</b>, B::<b>Base.LinAlg.AbstractTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L151\" target=\"_blank\">linalg/special.jl:151</a></li> <li> +(A::<b>Base.LinAlg.AbstractTriangular</b>, B::<b>Bidiagonal</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L150\" target=\"_blank\">linalg/special.jl:150</a></li> <li> +(A::<b>Bidiagonal</b>, B::<b>Base.LinAlg.AbstractTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L151\" target=\"_blank\">linalg/special.jl:151</a></li> <li> +(A::<b>Base.LinAlg.AbstractTriangular</b>, B::<b>Array{T,2} where T</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L150\" target=\"_blank\">linalg/special.jl:150</a></li> <li> +(A::<b>Array{T,2} where T</b>, B::<b>Base.LinAlg.AbstractTriangular</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/special.jl#L151\" target=\"_blank\">linalg/special.jl:151</a></li> <li> +(Y::<b>Union{Base.ReshapedArray{#s266,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{#s266,N}, SubArray{#s266,N,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where N where #s266<:Union{Base.Dates.CompoundPeriod, Base.Dates.Period}</b>, x::<b>Union{Base.Dates.CompoundPeriod, Base.Dates.Period}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/periods.jl#L363\" target=\"_blank\">dates/periods.jl:363</a></li> <li> +(X::<b>Union{Base.ReshapedArray{#s265,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{#s265,N}, SubArray{#s265,N,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where N where #s265<:Union{Base.Dates.CompoundPeriod, Base.Dates.Period}</b>, Y::<b>Union{Base.ReshapedArray{#s264,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{#s264,N}, SubArray{#s264,N,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where N where #s264<:Union{Base.Dates.CompoundPeriod, Base.Dates.Period}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/periods.jl#L364\" target=\"_blank\">dates/periods.jl:364</a></li> <li> +(x::<b>Union{Base.ReshapedArray{#s267,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{#s267,N}, SubArray{#s267,N,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where N where #s267<:Union{Base.Dates.CompoundPeriod, Base.Dates.Period}</b>, y::<b>Base.Dates.TimeType</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L86\" target=\"_blank\">dates/arithmetic.jl:86</a></li> <li> +(r::<b>Range{#s267} where #s267<:Base.Dates.TimeType</b>, x::<b>Base.Dates.Period</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/ranges.jl#L47\" target=\"_blank\">dates/ranges.jl:47</a></li> <li> +(A::<b>SparseMatrixCSC</b>, B::<b>SparseMatrixCSC</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/sparse/sparsematrix.jl#L1458\" target=\"_blank\">sparse/sparsematrix.jl:1458</a></li> <li> +(A::<b>SparseMatrixCSC</b>, B::<b>Array</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/sparse/sparsematrix.jl#L1461\" target=\"_blank\">sparse/sparsematrix.jl:1461</a></li> <li> +(x::<b>AbstractSparseArray{Tv,Ti,1} where Ti where Tv</b>, y::<b>AbstractSparseArray{Tv,Ti,1} where Ti where Tv</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/sparse/sparsevector.jl#L1332\" target=\"_blank\">sparse/sparsevector.jl:1332</a></li> <li> +(x::<b>AbstractSparseArray{Tv,Ti,1} where Ti where Tv</b>, y::<b>Union{Base.ReshapedArray{T,1,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{T,1}, SubArray{T,1,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where T</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/sparse/sparsevector.jl#L1334\" target=\"_blank\">sparse/sparsevector.jl:1334</a></li> <li> +(x::<b>AbstractArray{#s45,N} where N where #s45<:Number</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/abstractarraymath.jl#L93\" target=\"_blank\">abstractarraymath.jl:93</a></li> <li> +(A::<b>AbstractArray</b>, B::<b>AbstractArray</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/arraymath.jl#L37\" target=\"_blank\">arraymath.jl:37</a></li> <li> +(A::<b>Number</b>, B::<b>AbstractArray</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/arraymath.jl#L44\" target=\"_blank\">arraymath.jl:44</a></li> <li> +(A::<b>AbstractArray</b>, B::<b>Number</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/arraymath.jl#L47\" target=\"_blank\">arraymath.jl:47</a></li> <li> +<i>{N}</i>(index1::<b>CartesianIndex{N}</b>, index2::<b>CartesianIndex{N}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/multidimensional.jl#L70\" target=\"_blank\">multidimensional.jl:70</a></li> <li> +<i>{N}</i>(index::<b>CartesianIndex{N}</b>, i::<b>Integer</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/multidimensional.jl#L80\" target=\"_blank\">multidimensional.jl:80</a></li> <li> +(J1::<b>UniformScaling</b>, J2::<b>UniformScaling</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/uniformscaling.jl#L58\" target=\"_blank\">linalg/uniformscaling.jl:58</a></li> <li> +(J::<b>UniformScaling</b>, B::<b>BitArray{2}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/uniformscaling.jl#L60\" target=\"_blank\">linalg/uniformscaling.jl:60</a></li> <li> +(J::<b>UniformScaling</b>, A::<b>AbstractArray{T,2} where T</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/linalg/uniformscaling.jl#L61\" target=\"_blank\">linalg/uniformscaling.jl:61</a></li> <li> +<i>{T}</i>(a::<b>Base.Pkg.Resolve.VersionWeights.HierarchicalValue{T}</b>, b::<b>Base.Pkg.Resolve.VersionWeights.HierarchicalValue{T}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/pkg/resolve/versionweight.jl#L23\" target=\"_blank\">pkg/resolve/versionweight.jl:23</a></li> <li> +<i>{P<:Base.Dates.Period}</i>(x::<b>P</b>, y::<b>P</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/periods.jl#L70\" target=\"_blank\">dates/periods.jl:70</a></li> <li> +(x::<b>Base.Dates.Period</b>, y::<b>Base.Dates.Period</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/periods.jl#L346\" target=\"_blank\">dates/periods.jl:346</a></li> <li> +(y::<b>Base.Dates.Period</b>, x::<b>Base.Dates.CompoundPeriod</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/periods.jl#L348\" target=\"_blank\">dates/periods.jl:348</a></li> <li> +(x::<b>Union{Base.Dates.CompoundPeriod, Base.Dates.Period}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/periods.jl#L357\" target=\"_blank\">dates/periods.jl:357</a></li> <li> +(x::<b>Union{Base.Dates.CompoundPeriod, Base.Dates.Period}</b>, Y::<b>Union{Base.ReshapedArray{#s267,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{#s267,N}, SubArray{#s267,N,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where N where #s267<:Union{Base.Dates.CompoundPeriod, Base.Dates.Period}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/periods.jl#L362\" target=\"_blank\">dates/periods.jl:362</a></li> <li> +(x::<b>Base.Dates.TimeType</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L8\" target=\"_blank\">dates/arithmetic.jl:8</a></li> <li> +(a::<b>Base.Dates.TimeType</b>, b::<b>Base.Dates.Period</b>, c::<b>Base.Dates.Period</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/periods.jl#L378\" target=\"_blank\">dates/periods.jl:378</a></li> <li> +(a::<b>Base.Dates.TimeType</b>, b::<b>Base.Dates.Period</b>, c::<b>Base.Dates.Period</b>, d::<b>Base.Dates.Period...</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/periods.jl#L379\" target=\"_blank\">dates/periods.jl:379</a></li> <li> +(x::<b>Base.Dates.TimeType</b>, y::<b>Base.Dates.CompoundPeriod</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/periods.jl#L382\" target=\"_blank\">dates/periods.jl:382</a></li> <li> +(x::<b>Base.Dates.Instant</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L4\" target=\"_blank\">dates/arithmetic.jl:4</a></li> <li> +(y::<b>Base.Dates.Period</b>, x::<b>Base.Dates.TimeType</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L83\" target=\"_blank\">dates/arithmetic.jl:83</a></li> <li> +(x::<b>AbstractArray{#s267,N} where N where #s267<:Base.Dates.TimeType</b>, y::<b>Union{Base.Dates.CompoundPeriod, Base.Dates.Period}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L85\" target=\"_blank\">dates/arithmetic.jl:85</a></li> <li> +(x::<b>Base.Dates.Period</b>, r::<b>Range{#s267} where #s267<:Base.Dates.TimeType</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/ranges.jl#L46\" target=\"_blank\">dates/ranges.jl:46</a></li> <li> +(y::<b>Union{Base.Dates.CompoundPeriod, Base.Dates.Period}</b>, x::<b>AbstractArray{#s267,N} where N where #s267<:Base.Dates.TimeType</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L87\" target=\"_blank\">dates/arithmetic.jl:87</a></li> <li> +(y::<b>Base.Dates.TimeType</b>, x::<b>Union{Base.ReshapedArray{#s267,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{#s267,N}, SubArray{#s267,N,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where N where #s267<:Union{Base.Dates.CompoundPeriod, Base.Dates.Period}</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/dates/arithmetic.jl#L88\" target=\"_blank\">dates/arithmetic.jl:88</a></li> <li> +(J::<b>UniformScaling</b>, x::<b>Number</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/deprecated.jl#L56\" target=\"_blank\">deprecated.jl:56</a></li> <li> +(x::<b>Number</b>, J::<b>UniformScaling</b>) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/deprecated.jl#L56\" target=\"_blank\">deprecated.jl:56</a></li> <li> +(a, b, c, xs...) at <a href=\"https://github.com/JuliaLang/julia/tree/903644385b91ed8d95e5e3a5716c089dd1f1b08a/base/operators.jl#L424\" target=\"_blank\">operators.jl:424</a></li> </ul>"
+      ],
+      "text/plain": [
+       "# 180 methods for generic function \"+\":\n",
+       "+(x::Bool, z::Complex{Bool}) in Base at complex.jl:232\n",
+       "+(x::Bool, y::Bool) in Base at bool.jl:89\n",
+       "+(x::Bool) in Base at bool.jl:86\n",
+       "+(x::Bool, y::T) where T<:AbstractFloat in Base at bool.jl:96\n",
+       "+(x::Bool, z::Complex) in Base at complex.jl:239\n",
+       "+(a::Float16, b::Float16) in Base at float.jl:372\n",
+       "+(x::Float32, y::Float32) in Base at float.jl:374\n",
+       "+(x::Float64, y::Float64) in Base at float.jl:375\n",
+       "+(z::Complex{Bool}, x::Bool) in Base at complex.jl:233\n",
+       "+(z::Complex{Bool}, x::Real) in Base at complex.jl:247\n",
+       "+(x::Char, y::Integer) in Base at char.jl:40\n",
+       "+(c::BigInt, x::BigFloat) in Base.MPFR at mpfr.jl:312\n",
+       "+(a::BigInt, b::BigInt, c::BigInt, d::BigInt, e::BigInt) in Base.GMP at gmp.jl:334\n",
+       "+(a::BigInt, b::BigInt, c::BigInt, d::BigInt) in Base.GMP at gmp.jl:327\n",
+       "+(a::BigInt, b::BigInt, c::BigInt) in Base.GMP at gmp.jl:321\n",
+       "+(x::BigInt, y::BigInt) in Base.GMP at gmp.jl:289\n",
+       "+(x::BigInt, c::Union{UInt16, UInt32, UInt64, UInt8}) in Base.GMP at gmp.jl:346\n",
+       "+(x::BigInt, c::Union{Int16, Int32, Int64, Int8}) in Base.GMP at gmp.jl:362\n",
+       "+(a::BigFloat, b::BigFloat, c::BigFloat, d::BigFloat, e::BigFloat) in Base.MPFR at mpfr.jl:460\n",
+       "+(a::BigFloat, b::BigFloat, c::BigFloat, d::BigFloat) in Base.MPFR at mpfr.jl:453\n",
+       "+(a::BigFloat, b::BigFloat, c::BigFloat) in Base.MPFR at mpfr.jl:447\n",
+       "+(x::BigFloat, c::BigInt) in Base.MPFR at mpfr.jl:308\n",
+       "+(x::BigFloat, y::BigFloat) in Base.MPFR at mpfr.jl:277\n",
+       "+(x::BigFloat, c::Union{UInt16, UInt32, UInt64, UInt8}) in Base.MPFR at mpfr.jl:284\n",
+       "+(x::BigFloat, c::Union{Int16, Int32, Int64, Int8}) in Base.MPFR at mpfr.jl:292\n",
+       "+(x::BigFloat, c::Union{Float16, Float32, Float64}) in Base.MPFR at mpfr.jl:300\n",
+       "+(B::BitArray{2}, J::UniformScaling) in Base.LinAlg at linalg/uniformscaling.jl:59\n",
+       "+(a::Base.Pkg.Resolve.VersionWeights.VWPreBuildItem, b::Base.Pkg.Resolve.VersionWeights.VWPreBuildItem) in Base.Pkg.Resolve.VersionWeights at pkg/resolve/versionweight.jl:87\n",
+       "+(a::Base.Pkg.Resolve.VersionWeights.VWPreBuild, b::Base.Pkg.Resolve.VersionWeights.VWPreBuild) in Base.Pkg.Resolve.VersionWeights at pkg/resolve/versionweight.jl:135\n",
+       "+(a::Base.Pkg.Resolve.VersionWeights.VersionWeight, b::Base.Pkg.Resolve.VersionWeights.VersionWeight) in Base.Pkg.Resolve.VersionWeights at pkg/resolve/versionweight.jl:197\n",
+       "+(a::Base.Pkg.Resolve.MaxSum.FieldValues.FieldValue, b::Base.Pkg.Resolve.MaxSum.FieldValues.FieldValue) in Base.Pkg.Resolve.MaxSum.FieldValues at pkg/resolve/fieldvalue.jl:44\n",
+       "+(x::Base.Dates.CompoundPeriod, y::Base.Dates.CompoundPeriod) in Base.Dates at dates/periods.jl:349\n",
+       "+(x::Base.Dates.CompoundPeriod, y::Base.Dates.Period) in Base.Dates at dates/periods.jl:347\n",
+       "+(x::Base.Dates.CompoundPeriod, y::Base.Dates.TimeType) in Base.Dates at dates/periods.jl:387\n",
+       "+(x::Date, y::Base.Dates.Day) in Base.Dates at dates/arithmetic.jl:77\n",
+       "+(x::Date, y::Base.Dates.Week) in Base.Dates at dates/arithmetic.jl:75\n",
+       "+(dt::Date, z::Base.Dates.Month) in Base.Dates at dates/arithmetic.jl:58\n",
+       "+(dt::Date, y::Base.Dates.Year) in Base.Dates at dates/arithmetic.jl:32\n",
+       "+(dt::Date, t::Base.Dates.Time) in Base.Dates at dates/arithmetic.jl:20\n",
+       "+(t::Base.Dates.Time, dt::Date) in Base.Dates at dates/arithmetic.jl:24\n",
+       "+(x::Base.Dates.Time, y::Base.Dates.TimePeriod) in Base.Dates at dates/arithmetic.jl:81\n",
+       "+(dt::DateTime, z::Base.Dates.Month) in Base.Dates at dates/arithmetic.jl:52\n",
+       "+(dt::DateTime, y::Base.Dates.Year) in Base.Dates at dates/arithmetic.jl:28\n",
+       "+(x::DateTime, y::Base.Dates.Period) in Base.Dates at dates/arithmetic.jl:79\n",
+       "+(y::AbstractFloat, x::Bool) in Base at bool.jl:98\n",
+       "+(x::T, y::T) where T<:Union{Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64, UInt8} in Base at int.jl:32\n",
+       "+(x::Integer, y::Ptr) in Base at pointer.jl:128\n",
+       "+(z::Complex, w::Complex) in Base at complex.jl:221\n",
+       "+(z::Complex, x::Bool) in Base at complex.jl:240\n",
+       "+(x::Real, z::Complex{Bool}) in Base at complex.jl:246\n",
+       "+(x::Real, z::Complex) in Base at complex.jl:258\n",
+       "+(z::Complex, x::Real) in Base at complex.jl:259\n",
+       "+(x::Rational, y::Rational) in Base at rational.jl:245\n",
+       "+(x::Integer, y::Char) in Base at char.jl:41\n",
+       "+(i::Integer, index::CartesianIndex) in Base.IteratorsMD at multidimensional.jl:79\n",
+       "+(c::Union{UInt16, UInt32, UInt64, UInt8}, x::BigInt) in Base.GMP at gmp.jl:350\n",
+       "+(c::Union{Int16, Int32, Int64, Int8}, x::BigInt) in Base.GMP at gmp.jl:363\n",
+       "+(c::Union{UInt16, UInt32, UInt64, UInt8}, x::BigFloat) in Base.MPFR at mpfr.jl:288\n",
+       "+(c::Union{Int16, Int32, Int64, Int8}, x::BigFloat) in Base.MPFR at mpfr.jl:296\n",
+       "+(c::Union{Float16, Float32, Float64}, x::BigFloat) in Base.MPFR at mpfr.jl:304\n",
+       "+(x::Irrational, y::Irrational) in Base at irrationals.jl:109\n",
+       "+(x::Real, r::Base.Use_StepRangeLen_Instead) in Base at deprecated.jl:1223\n",
+       "+(x::Number) in Base at operators.jl:399\n",
+       "+(x::T, y::T) where T<:Number in Base at promotion.jl:335\n",
+       "+(x::Number, y::Number) in Base at promotion.jl:249\n",
+       "+(x::Real, r::AbstractUnitRange) in Base at range.jl:721\n",
+       "+(x::Number, r::AbstractUnitRange) in Base at range.jl:723\n",
+       "+(x::Number, r::StepRangeLen) in Base at range.jl:726\n",
+       "+(x::Number, r::LinSpace) in Base at range.jl:730\n",
+       "+(x::Number, r::Range) in Base at range.jl:724\n",
+       "+(r::Range, x::Number) in Base at range.jl:732\n",
+       "+(r1::OrdinalRange, r2::OrdinalRange) in Base at range.jl:882\n",
+       "+(r1::LinSpace{T}, r2::LinSpace{T}) where T in Base at range.jl:889\n",
+       "+(r1::StepRangeLen{T,R,S} where S, r2::StepRangeLen{T,R,S} where S) where {R<:Base.TwicePrecision, T} in Base at twiceprecision.jl:300\n",
+       "+(r1::StepRangeLen{T,S,S} where S, r2::StepRangeLen{T,S,S} where S) where {T, S} in Base at range.jl:905\n",
+       "+(r1::Union{LinSpace, OrdinalRange, StepRangeLen}, r2::Union{LinSpace, OrdinalRange, StepRangeLen}) in Base at range.jl:896\n",
+       "+(x::Base.TwicePrecision, y::Number) in Base at twiceprecision.jl:454\n",
+       "+(x::Number, y::Base.TwicePrecision) in Base at twiceprecision.jl:457\n",
+       "+(x::Base.TwicePrecision{T}, y::Base.TwicePrecision{T}) where T in Base at twiceprecision.jl:460\n",
+       "+(x::Base.TwicePrecision, y::Base.TwicePrecision) in Base at twiceprecision.jl:464\n",
+       "+(x::Ptr, y::Integer) in Base at pointer.jl:126\n",
+       "+(A::BitArray, B::BitArray) in Base at bitarray.jl:1176\n",
+       "+(A::SymTridiagonal, B::SymTridiagonal) in Base.LinAlg at linalg/tridiag.jl:128\n",
+       "+(A::Tridiagonal, B::Tridiagonal) in Base.LinAlg at linalg/tridiag.jl:624\n",
+       "+(A::UpperTriangular, B::UpperTriangular) in Base.LinAlg at linalg/triangular.jl:374\n",
+       "+(A::LowerTriangular, B::LowerTriangular) in Base.LinAlg at linalg/triangular.jl:375\n",
+       "+(A::UpperTriangular, B::Base.LinAlg.UnitUpperTriangular) in Base.LinAlg at linalg/triangular.jl:376\n",
+       "+(A::LowerTriangular, B::Base.LinAlg.UnitLowerTriangular) in Base.LinAlg at linalg/triangular.jl:377\n",
+       "+(A::Base.LinAlg.UnitUpperTriangular, B::UpperTriangular) in Base.LinAlg at linalg/triangular.jl:378\n",
+       "+(A::Base.LinAlg.UnitLowerTriangular, B::LowerTriangular) in Base.LinAlg at linalg/triangular.jl:379\n",
+       "+(A::Base.LinAlg.UnitUpperTriangular, B::Base.LinAlg.UnitUpperTriangular) in Base.LinAlg at linalg/triangular.jl:380\n",
+       "+(A::Base.LinAlg.UnitLowerTriangular, B::Base.LinAlg.UnitLowerTriangular) in Base.LinAlg at linalg/triangular.jl:381\n",
+       "+(A::Base.LinAlg.AbstractTriangular, B::Base.LinAlg.AbstractTriangular) in Base.LinAlg at linalg/triangular.jl:382\n",
+       "+(A::Symmetric, x::Bool) in Base.LinAlg at linalg/symmetric.jl:272\n",
+       "+(A::Symmetric, x::Number) in Base.LinAlg at linalg/symmetric.jl:274\n",
+       "+(A::Hermitian, x::Bool) in Base.LinAlg at linalg/symmetric.jl:272\n",
+       "+(A::Hermitian, x::Real) in Base.LinAlg at linalg/symmetric.jl:274\n",
+       "+(Da::Diagonal, Db::Diagonal) in Base.LinAlg at linalg/diagonal.jl:140\n",
+       "+(A::Bidiagonal, B::Bidiagonal) in Base.LinAlg at linalg/bidiag.jl:330\n",
+       "+(UL::UpperTriangular, J::UniformScaling) in Base.LinAlg at linalg/uniformscaling.jl:72\n",
+       "+(UL::Base.LinAlg.UnitUpperTriangular, J::UniformScaling) in Base.LinAlg at linalg/uniformscaling.jl:75\n",
+       "+(UL::LowerTriangular, J::UniformScaling) in Base.LinAlg at linalg/uniformscaling.jl:72\n",
+       "+(UL::Base.LinAlg.UnitLowerTriangular, J::UniformScaling) in Base.LinAlg at linalg/uniformscaling.jl:75\n",
+       "+(A::Array, B::SparseMatrixCSC) in Base.SparseArrays at sparse/sparsematrix.jl:1462\n",
+       "+(x::Union{Base.ReshapedArray{T,1,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{T,1}, SubArray{T,1,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where T, y::AbstractSparseArray{Tv,Ti,1} where Ti where Tv) in Base.SparseArrays at sparse/sparsevector.jl:1333\n",
+       "+(x::Union{Base.ReshapedArray{#s267,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{#s267,N}, SubArray{#s267,N,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where N where #s267<:Union{Base.Dates.CompoundPeriod, Base.Dates.Period}) in Base.Dates at dates/periods.jl:358\n",
+       "+(A::SparseMatrixCSC, J::UniformScaling) in Base.SparseArrays at sparse/sparsematrix.jl:3512\n",
+       "+(A::AbstractArray{TA,2}, J::UniformScaling{TJ}) where {TA, TJ} in Base.LinAlg at linalg/uniformscaling.jl:119\n",
+       "+(A::Diagonal, B::Bidiagonal) in Base.LinAlg at linalg/special.jl:113\n",
+       "+(A::Bidiagonal, B::Diagonal) in Base.LinAlg at linalg/special.jl:114\n",
+       "+(A::Diagonal, B::Tridiagonal) in Base.LinAlg at linalg/special.jl:113\n",
+       "+(A::Tridiagonal, B::Diagonal) in Base.LinAlg at linalg/special.jl:114\n",
+       "+(A::Diagonal, B::Array{T,2} where T) in Base.LinAlg at linalg/special.jl:113\n",
+       "+(A::Array{T,2} where T, B::Diagonal) in Base.LinAlg at linalg/special.jl:114\n",
+       "+(A::Bidiagonal, B::Tridiagonal) in Base.LinAlg at linalg/special.jl:113\n",
+       "+(A::Tridiagonal, B::Bidiagonal) in Base.LinAlg at linalg/special.jl:114\n",
+       "+(A::Bidiagonal, B::Array{T,2} where T) in Base.LinAlg at linalg/special.jl:113\n",
+       "+(A::Array{T,2} where T, B::Bidiagonal) in Base.LinAlg at linalg/special.jl:114\n",
+       "+(A::Tridiagonal, B::Array{T,2} where T) in Base.LinAlg at linalg/special.jl:113\n",
+       "+(A::Array{T,2} where T, B::Tridiagonal) in Base.LinAlg at linalg/special.jl:114\n",
+       "+(A::SymTridiagonal, B::Tridiagonal) in Base.LinAlg at linalg/special.jl:122\n",
+       "+(A::Tridiagonal, B::SymTridiagonal) in Base.LinAlg at linalg/special.jl:123\n",
+       "+(A::SymTridiagonal, B::Array{T,2} where T) in Base.LinAlg at linalg/special.jl:122\n",
+       "+(A::Array{T,2} where T, B::SymTridiagonal) in Base.LinAlg at linalg/special.jl:123\n",
+       "+(A::Diagonal, B::SymTridiagonal) in Base.LinAlg at linalg/special.jl:131\n",
+       "+(A::SymTridiagonal, B::Diagonal) in Base.LinAlg at linalg/special.jl:132\n",
+       "+(A::Bidiagonal, B::SymTridiagonal) in Base.LinAlg at linalg/special.jl:131\n",
+       "+(A::SymTridiagonal, B::Bidiagonal) in Base.LinAlg at linalg/special.jl:132\n",
+       "+(A::Diagonal, B::UpperTriangular) in Base.LinAlg at linalg/special.jl:143\n",
+       "+(A::UpperTriangular, B::Diagonal) in Base.LinAlg at linalg/special.jl:144\n",
+       "+(A::Diagonal, B::Base.LinAlg.UnitUpperTriangular) in Base.LinAlg at linalg/special.jl:143\n",
+       "+(A::Base.LinAlg.UnitUpperTriangular, B::Diagonal) in Base.LinAlg at linalg/special.jl:144\n",
+       "+(A::Diagonal, B::LowerTriangular) in Base.LinAlg at linalg/special.jl:143\n",
+       "+(A::LowerTriangular, B::Diagonal) in Base.LinAlg at linalg/special.jl:144\n",
+       "+(A::Diagonal, B::Base.LinAlg.UnitLowerTriangular) in Base.LinAlg at linalg/special.jl:143\n",
+       "+(A::Base.LinAlg.UnitLowerTriangular, B::Diagonal) in Base.LinAlg at linalg/special.jl:144\n",
+       "+(A::Base.LinAlg.AbstractTriangular, B::SymTridiagonal) in Base.LinAlg at linalg/special.jl:150\n",
+       "+(A::SymTridiagonal, B::Base.LinAlg.AbstractTriangular) in Base.LinAlg at linalg/special.jl:151\n",
+       "+(A::Base.LinAlg.AbstractTriangular, B::Tridiagonal) in Base.LinAlg at linalg/special.jl:150\n",
+       "+(A::Tridiagonal, B::Base.LinAlg.AbstractTriangular) in Base.LinAlg at linalg/special.jl:151\n",
+       "+(A::Base.LinAlg.AbstractTriangular, B::Bidiagonal) in Base.LinAlg at linalg/special.jl:150\n",
+       "+(A::Bidiagonal, B::Base.LinAlg.AbstractTriangular) in Base.LinAlg at linalg/special.jl:151\n",
+       "+(A::Base.LinAlg.AbstractTriangular, B::Array{T,2} where T) in Base.LinAlg at linalg/special.jl:150\n",
+       "+(A::Array{T,2} where T, B::Base.LinAlg.AbstractTriangular) in Base.LinAlg at linalg/special.jl:151\n",
+       "+(Y::Union{Base.ReshapedArray{#s266,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{#s266,N}, SubArray{#s266,N,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where N where #s266<:Union{Base.Dates.CompoundPeriod, Base.Dates.Period}, x::Union{Base.Dates.CompoundPeriod, Base.Dates.Period}) in Base.Dates at dates/periods.jl:363\n",
+       "+(X::Union{Base.ReshapedArray{#s265,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{#s265,N}, SubArray{#s265,N,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where N where #s265<:Union{Base.Dates.CompoundPeriod, Base.Dates.Period}, Y::Union{Base.ReshapedArray{#s264,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{#s264,N}, SubArray{#s264,N,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where N where #s264<:Union{Base.Dates.CompoundPeriod, Base.Dates.Period}) in Base.Dates at dates/periods.jl:364\n",
+       "+(x::Union{Base.ReshapedArray{#s267,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{#s267,N}, SubArray{#s267,N,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where N where #s267<:Union{Base.Dates.CompoundPeriod, Base.Dates.Period}, y::Base.Dates.TimeType) in Base.Dates at dates/arithmetic.jl:86\n",
+       "+(r::Range{#s267} where #s267<:Base.Dates.TimeType, x::Base.Dates.Period) in Base.Dates at dates/ranges.jl:47\n",
+       "+(A::SparseMatrixCSC, B::SparseMatrixCSC) in Base.SparseArrays at sparse/sparsematrix.jl:1458\n",
+       "+(A::SparseMatrixCSC, B::Array) in Base.SparseArrays at sparse/sparsematrix.jl:1461\n",
+       "+(x::AbstractSparseArray{Tv,Ti,1} where Ti where Tv, y::AbstractSparseArray{Tv,Ti,1} where Ti where Tv) in Base.SparseArrays at sparse/sparsevector.jl:1332\n",
+       "+(x::AbstractSparseArray{Tv,Ti,1} where Ti where Tv, y::Union{Base.ReshapedArray{T,1,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{T,1}, SubArray{T,1,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where T) in Base.SparseArrays at sparse/sparsevector.jl:1334\n",
+       "+(x::AbstractArray{#s45,N} where N where #s45<:Number) in Base at abstractarraymath.jl:93\n",
+       "+(A::AbstractArray, B::AbstractArray) in Base at arraymath.jl:37\n",
+       "+(A::Number, B::AbstractArray) in Base at arraymath.jl:44\n",
+       "+(A::AbstractArray, B::Number) in Base at arraymath.jl:47\n",
+       "+(index1::CartesianIndex{N}, index2::CartesianIndex{N}) where N in Base.IteratorsMD at multidimensional.jl:70\n",
+       "+(index::CartesianIndex{N}, i::Integer) where N in Base.IteratorsMD at multidimensional.jl:80\n",
+       "+(J1::UniformScaling, J2::UniformScaling) in Base.LinAlg at linalg/uniformscaling.jl:58\n",
+       "+(J::UniformScaling, B::BitArray{2}) in Base.LinAlg at linalg/uniformscaling.jl:60\n",
+       "+(J::UniformScaling, A::AbstractArray{T,2} where T) in Base.LinAlg at linalg/uniformscaling.jl:61\n",
+       "+(a::Base.Pkg.Resolve.VersionWeights.HierarchicalValue{T}, b::Base.Pkg.Resolve.VersionWeights.HierarchicalValue{T}) where T in Base.Pkg.Resolve.VersionWeights at pkg/resolve/versionweight.jl:23\n",
+       "+(x::P, y::P) where P<:Base.Dates.Period in Base.Dates at dates/periods.jl:70\n",
+       "+(x::Base.Dates.Period, y::Base.Dates.Period) in Base.Dates at dates/periods.jl:346\n",
+       "+(y::Base.Dates.Period, x::Base.Dates.CompoundPeriod) in Base.Dates at dates/periods.jl:348\n",
+       "+(x::Union{Base.Dates.CompoundPeriod, Base.Dates.Period}) in Base.Dates at dates/periods.jl:357\n",
+       "+(x::Union{Base.Dates.CompoundPeriod, Base.Dates.Period}, Y::Union{Base.ReshapedArray{#s267,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{#s267,N}, SubArray{#s267,N,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where N where #s267<:Union{Base.Dates.CompoundPeriod, Base.Dates.Period}) in Base.Dates at dates/periods.jl:362\n",
+       "+(x::Base.Dates.TimeType) in Base.Dates at dates/arithmetic.jl:8\n",
+       "+(a::Base.Dates.TimeType, b::Base.Dates.Period, c::Base.Dates.Period) in Base.Dates at dates/periods.jl:378\n",
+       "+(a::Base.Dates.TimeType, b::Base.Dates.Period, c::Base.Dates.Period, d::Base.Dates.Period...) in Base.Dates at dates/periods.jl:379\n",
+       "+(x::Base.Dates.TimeType, y::Base.Dates.CompoundPeriod) in Base.Dates at dates/periods.jl:382\n",
+       "+(x::Base.Dates.Instant) in Base.Dates at dates/arithmetic.jl:4\n",
+       "+(y::Base.Dates.Period, x::Base.Dates.TimeType) in Base.Dates at dates/arithmetic.jl:83\n",
+       "+(x::AbstractArray{#s267,N} where N where #s267<:Base.Dates.TimeType, y::Union{Base.Dates.CompoundPeriod, Base.Dates.Period}) in Base.Dates at dates/arithmetic.jl:85\n",
+       "+(x::Base.Dates.Period, r::Range{#s267} where #s267<:Base.Dates.TimeType) in Base.Dates at dates/ranges.jl:46\n",
+       "+(y::Union{Base.Dates.CompoundPeriod, Base.Dates.Period}, x::AbstractArray{#s267,N} where N where #s267<:Base.Dates.TimeType) in Base.Dates at dates/arithmetic.jl:87\n",
+       "+(y::Base.Dates.TimeType, x::Union{Base.ReshapedArray{#s267,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray, DenseArray{#s267,N}, SubArray{#s267,N,A,I,L} where L} where I<:Tuple{Vararg{Union{Base.AbstractCartesianIndex, Int64, Range{Int64}},N} where N} where A<:Union{Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:DenseArray where N where T, DenseArray} where N where #s267<:Union{Base.Dates.CompoundPeriod, Base.Dates.Period}) in Base.Dates at dates/arithmetic.jl:88\n",
+       "+(J::UniformScaling, x::Number) in Base at deprecated.jl:56\n",
+       "+(x::Number, J::UniformScaling) in Base at deprecated.jl:56\n",
+       "+(a, b, c, xs...) in Base at operators.jl:424"
+      ]
+     },
+     "execution_count": 65,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "methods(+)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A good design of Julia code makes sure that different problems map to different types, or that different properties of a problem match to different types. You write the algorithms in terms of these types, and Julia makes sure that the right algorithm is called at the right time. As you see, this is not entirely for free. It is not really the case that Julia selects the right algorithm. Julia selects the method that best matches the type signature. It is up to you, the programmer, to make sure that this corresponds to the right algorithm.\n",
+    "\n",
+    "This does mean that multiple dispatch affects the design of your code. You design data structures with dispatch in mind, and you write algorithms that apply to types. This is not difficult to achieve once you're used to it, but it is quite pervasive and it is so pretty much from the start."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### More fun\n",
+    "Macro's + parallel code"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Julia 0.6.0",
+   "language": "julia",
+   "name": "julia-0.6"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "0.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/Julia-introduction-SIAM-SC.ipynb
+++ b/Julia-introduction-SIAM-SC.ipynb
@@ -11,17 +11,8 @@
     "\n",
     "This notebook is a collection of small code snippets illustrating different aspects of Julia.\n",
     "\n",
-    "Most examples where taken from [the notebooks of Daan Huybrechs](https://github.com/daanhb/Julia-tutorial)."
+    "Most examples (~98%) where taken from [the notebooks of Daan Huybrechs](https://github.com/daanhb/Julia-tutorial)."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
I updated the syntax of the code to the current stable Julia version (0.6 at the time of writing). The result is that no deprecation warnings will be shown anymore (when using 0.6), and will be able to run on newer versions (it worked on nightly 0.7 build).

Secondly, I created a short notebook which only shows some important features of Julia. The examples with associated explanation have been reused from the main 4 notebooks. This can be used in a shorter introductory workshop.